### PR TITLE
fix: resolve netbird_group update conversion errors (netbird#104)

### DIFF
--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -133,6 +133,62 @@ func groupAPIToTerraform(ctx context.Context, group *api.Group, data *GroupModel
 	return ret
 }
 
+func (r *Group) groupRequestResources(ctx context.Context, resourceIDs types.List) (*[]api.Resource, diag.Diagnostics) {
+	var ret diag.Diagnostics
+
+	if resourceIDs.IsUnknown() || resourceIDs.IsNull() {
+		return nil, ret
+	}
+
+	var ids []string
+	ret.Append(resourceIDs.ElementsAs(ctx, &ids, false)...)
+	if ret.HasError() {
+		return nil, ret
+	}
+
+	resources := make([]api.Resource, 0, len(ids))
+	if len(ids) == 0 {
+		return &resources, ret
+	}
+
+	networks, err := r.client.Networks.List(ctx)
+	if err != nil {
+		ret.AddError("Error listing networks", err.Error())
+		return nil, ret
+	}
+
+	resourceTypes := make(map[string]api.ResourceType)
+	for _, network := range networks {
+		networkResources, err := r.client.Networks.Resources(network.Id).List(ctx)
+		if err != nil {
+			ret.AddError("Error listing network resources", err.Error())
+			return nil, ret
+		}
+
+		for _, networkResource := range networkResources {
+			resourceTypes[networkResource.Id] = api.ResourceType(networkResource.Type)
+		}
+	}
+
+	for _, id := range ids {
+		resourceType, ok := resourceTypes[id]
+		if !ok {
+			ret.AddError(
+				"Unknown network resource",
+				fmt.Sprintf("Could not resolve network resource %q while preparing the group request.", id),
+			)
+			return nil, ret
+		}
+
+		resources = append(resources, api.Resource{
+			Id:   id,
+			Type: resourceType,
+		})
+	}
+
+	return &resources, ret
+}
+
 func (r *Group) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data GroupModel
 
@@ -143,21 +199,10 @@ func (r *Group) Create(ctx context.Context, req resource.CreateRequest, resp *re
 		return
 	}
 
-	var resources *[]api.Resource
-	if len(data.Resources.Elements()) > 0 {
-		var tfVal []map[string]string
-		var resourcesVal []api.Resource
-		resp.Diagnostics.Append(data.Resources.ElementsAs(ctx, &tfVal, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		for _, v := range tfVal {
-			resourcesVal = append(resourcesVal, api.Resource{
-				Id:   v["id"],
-				Type: api.ResourceType(v["type"]),
-			})
-		}
-		resources = &resourcesVal
+	resources, diags := r.groupRequestResources(ctx, data.Resources)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	groupReq := api.GroupRequest{
@@ -228,21 +273,10 @@ func (r *Group) Update(ctx context.Context, req resource.UpdateRequest, resp *re
 		return
 	}
 
-	var resources *[]api.Resource
-	if len(data.Resources.Elements()) > 0 {
-		var tfVal []map[string]string
-		var resourcesVal []api.Resource
-		resp.Diagnostics.Append(data.Resources.ElementsAs(ctx, &tfVal, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		for _, v := range tfVal {
-			resourcesVal = append(resourcesVal, api.Resource{
-				Id:   v["id"],
-				Type: api.ResourceType(v["type"]),
-			})
-		}
-		resources = &resourcesVal
+	resources, diags := r.groupRequestResources(ctx, data.Resources)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	groupReq := api.GroupRequest{

--- a/internal/provider/group_test.go
+++ b/internal/provider/group_test.go
@@ -172,9 +172,121 @@ func Test_Group_Update(t *testing.T) {
 	})
 }
 
+func Test_Group_Update_PeersWithResources(t *testing.T) {
+	rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_group." + rName
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			groups, err := testClient().Groups.List(context.Background())
+			if err != nil {
+				return err
+			}
+			for _, g := range groups {
+				if g.Name == rName {
+					return fmt.Errorf("Group not deleted")
+				}
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       testGroupResourceWithResources(rName, `[]`, `["resource1"]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "name", rName),
+					resource.TestCheckResourceAttr(rNameFull, "peers.#", "0"),
+					resource.TestCheckResourceAttr(rNameFull, "resources.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "resources.0", "resource1"),
+					func(s *terraform.State) error {
+						gID := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]
+						group, err := testClient().Groups.Get(context.Background(), gID)
+						if err != nil {
+							return err
+						}
+						if len(group.Peers) != 0 {
+							return fmt.Errorf("Group Peers incorrect")
+						}
+						if len(group.Resources) != 1 {
+							return fmt.Errorf("Group Resources not updated in management")
+						}
+						if group.Resources[0].Id != "resource1" {
+							return fmt.Errorf("Group Resources incorrect")
+						}
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName: rName,
+				Config:       testGroupResourceWithResources(rName, `["peer1"]`, `["resource1"]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "name", rName),
+					resource.TestCheckResourceAttr(rNameFull, "peers.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "peers.0", "peer1"),
+					resource.TestCheckResourceAttr(rNameFull, "resources.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "resources.0", "resource1"),
+					func(s *terraform.State) error {
+						gID := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]
+						group, err := testClient().Groups.Get(context.Background(), gID)
+						if err != nil {
+							return err
+						}
+						if len(group.Peers) != 1 {
+							return fmt.Errorf("Group Peers not updated in management")
+						}
+						if group.Peers[0].Id != "peer1" {
+							return fmt.Errorf("Group Peers incorrect")
+						}
+						if len(group.Resources) != 1 {
+							return fmt.Errorf("Group Resources not preserved in management")
+						}
+						if group.Resources[0].Id != "resource1" {
+							return fmt.Errorf("Group Resources incorrect")
+						}
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName: rName,
+				Config:       testGroupResourceWithResources(rName, `[]`, `[]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "name", rName),
+					resource.TestCheckResourceAttr(rNameFull, "peers.#", "0"),
+					resource.TestCheckResourceAttr(rNameFull, "resources.#", "0"),
+					func(s *terraform.State) error {
+						gID := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]
+						group, err := testClient().Groups.Get(context.Background(), gID)
+						if err != nil {
+							return err
+						}
+						if len(group.Peers) != 0 {
+							return fmt.Errorf("Group Peers not cleared in management")
+						}
+						if len(group.Resources) != 0 {
+							return fmt.Errorf("Group Resources not cleared in management")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func testGroupResource(rName, peers string) string {
+	return testGroupResourceWithResources(rName, peers, `[]`)
+}
+
+func testGroupResourceWithResources(rName, peers, resources string) string {
 	return fmt.Sprintf(`resource "netbird_group" "%s" {
 	name = "%s"
 	peers = %s
-}`, rName, rName, peers)
+	resources = %s
+}`, rName, rName, peers, resources)
 }


### PR DESCRIPTION
  ## Summary

  This PR fixes `netbird_group` update failures caused by a Terraform Plugin Framework value conversion error.

  The failure was visible while updating `peers`, but the actual provider bug was in how `resources` were decoded when building the group update request.

  ## Problem

  `netbird_group` is documented to accept peer IDs as a list of strings, for example:

  ```hcl
  resource "netbird_group" "home_internal_net_routing_peers" {
    name  = "home-internal-net-routing-peers"
    peers = ["d6lc1brl0ubs739v89ig"]
  }
```

  Terraform produced the expected plan:

```
  ~ resource "netbird_group" "home_internal_net_routing_peers" {
      id    = "d6s40jrl0ubs73ergjr0"
      name  = "home-internal-net-routing-peers"
    ~ peers = [
        + "d6lc1brl0ubs739v89ig",
      ]
  }
```

  But `terraform apply` failed with a provider-side error:

  Error: Value Conversion Error

  An unexpected error was encountered trying to convert tftypes.Value into map[string]string.
  cannot reflect tftypes.String into a map, must be a map

  ## Root Cause

  In the Terraform schema and generated docs, both peers and resources are exposed as list(string).

  However, the netbird_group create/update implementation was trying to decode resources as []map[string]string, as if Terraform were providing objects like:

```
  resources = [
    {
      id   = "resource1"
      type = "domain"
    }
  ]
```

  That is not what the resource schema declares or what Terraform stores in state.

  As a result, if a group already had resources in state, even a peers-only update could fail before the provider ever sent the API request.

  ## What Changed

  This PR keeps the public Terraform interface unchanged and fixes the provider internals:

  - peers remains list(string)
  - resources remains list(string)
  - the incorrect []map[string]string conversion was removed from netbird_group create/update handling
  - resource IDs from Terraform state are now resolved into the NetBird API request shape (api.Resource{Id, Type}) before calling the API
  - the same logic is used in both create and update paths

  ## Why Existing Tests Did Not Catch It

  The repository already had an acceptance test for updating netbird_group, but it only covered this sequence:

  1. create a group with peers = []
  2. update it to peers = ["peer1"]

  That test never assigned any resources, so the broken resources decoding path was not executed.

  In other words, the test covered peer updates in isolation, but not the real-world state shape that triggered the conversion error.

  ## Test Coverage Added

  This PR adds an acceptance regression test that covers the failing scenario end to end:

  1. create a group with resources = ["resource1"]
  2. update the same group to peers = ["peer1"]
  3. verify Terraform state and NetBird API state
  4. clear both peers and resources so destroy succeeds cleanly

  Example test flow:

```
  resource "netbird_group" "example" {
    name      = "example"
    peers     = []
    resources = ["resource1"]
  }
```

  then:

```
  resource "netbird_group" "example" {
    name      = "example"
    peers     = ["peer1"]
    resources = ["resource1"]
  }
```

  and finally:

```
  resource "netbird_group" "example" {
    name      = "example"
    peers     = []
    resources = []
  }
```

  ## Result

  After this change:

  - peer updates on netbird_group no longer fail with Value Conversion Error
  - existing group resources are preserved correctly during updates
  - empty-list cleanup works correctly
  - the regression is covered by acceptance tests

  ## Compatibility

  This is a bug fix only.

  - no schema changes
  - no state migration
  - no configuration changes required for existing users
  - documented netbird_group usage remains valid

  ## Validation

  Validated with:

```
  TF_ACC=1 go test -v ./internal/provider -run 'Test_groupAPIToTerraform|Test_Group_Create$|Test_Group_Update$|Test_Group_Update_PeersWithResources'
```