### PR TITLE
Fix inconsistency issue with policy rule description

### DIFF
--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -333,8 +333,8 @@ func policyAPIToTerraform(ctx context.Context, policy *api.Policy, data *PolicyM
 			Bidirectional: types.BoolValue(r.Bidirectional),
 			Description:   types.StringPointerValue(r.Description),
 		}
-		if r.Description == nil || *r.Description == "" {
-			ruleModel.Description = types.StringNull()
+		if r.Description == nil {
+			ruleModel.Description = types.StringValue("")
 		}
 		if r.Sources != nil {
 			var sources []string

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -156,6 +156,8 @@ func (r *Policy) Schema(ctx context.Context, req resource.SchemaRequest, resp *r
 						"description": schema.StringAttribute{
 							MarkdownDescription: "Policy description",
 							Optional:            true,
+							Computed:            true,
+							Default:             stringdefault.StaticString(""),
 						},
 						"action": schema.StringAttribute{
 							MarkdownDescription: "Policy Rule Action (accept|drop)",

--- a/internal/provider/policy_test.go
+++ b/internal/provider/policy_test.go
@@ -170,7 +170,7 @@ func Test_policyAPIToTerraform(t *testing.T) {
 					"id":                   types.StringValue("r3"),
 					"action":               types.StringValue("accept"),
 					"bidirectional":        types.BoolValue(true),
-					"description":          types.StringNull(),
+					"description":          types.StringValue(""),
 					"sources":              types.ListValueMust(types.StringType, []attr.Value{types.StringValue("g1")}),
 					"destinations":         types.ListValueMust(types.StringType, []attr.Value{types.StringValue("g2")}),
 					"enabled":              types.BoolValue(true),


### PR DESCRIPTION
Same root cause as #45 / #50, applied to the nested policy rule `description` attribute on `netbird_policy`.

When `description` is omitted on a rule, the plan records it as null but the API returns `""`, producing a "Provider produced inconsistent result after apply" error.

Mirrors the fix from #50 on `netbird_network`: mark the attribute `Computed` and give it a `stringdefault.StaticString("")` default so plan and applied state agree. The top-level `netbird_policy.description` is already `Computed` (with a `UseStateForUnknown` plan modifier) so it's not affected by the same bug; this PR only touches the nested rule attribute.
