### PR TITLE
fix(network_resource): allow resources without group

### DIFF
--- a/docs/resources/network_resource.md
+++ b/docs/resources/network_resource.md
@@ -38,7 +38,6 @@ resource "netbird_network_resource" "example" {
 ### Required
 
 - `address` (String) Network resource address (either a direct host like 1.1.1.1 or 1.1.1.1/32, or a subnet like 192.168.178.0/24, or domains like example.com and *.example.com)
-- `groups` (Set of String) Group IDs containing the resource
 - `name` (String) NetworkResource Name
 - `network_id` (String) The unique identifier of a network
 
@@ -46,6 +45,7 @@ resource "netbird_network_resource" "example" {
 
 - `description` (String) NetworkResource Description
 - `enabled` (Boolean) NetworkResource status
+- `groups` (Set of String) Group IDs containing the resource
 
 ### Read-Only
 

--- a/internal/provider/network_resource_acc_test.go
+++ b/internal/provider/network_resource_acc_test.go
@@ -68,6 +68,49 @@ func Test_NetworkResource_Create(t *testing.T) {
 	})
 }
 
+func Test_NetworkResource_Create_NoGroups(t *testing.T) {
+	testE2E(t)
+	rName := "nre" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_network_resource." + rName
+	var createdID string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testCheckGone(func(ctx context.Context, id string) (*api.NetworkResource, error) {
+			return testClient().Networks.Resources(e2eNetworkID()).Get(ctx, id)
+		}, &createdID),
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       testNetworkResourceResource(rName, e2eNetworkID(), `example.com`, `null`, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "groups.#", "0"),
+					func(s *terraform.State) error {
+						nreID := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]
+						resource, err := testClient().Networks.Resources(e2eNetworkID()).Get(context.Background(), nreID)
+						if err != nil {
+							return err
+						}
+
+						if len(resource.Groups) != 0 {
+							return fmt.Errorf("NetworkResource Groups mismatch, expected empty, found %#v on management server", resource.Groups)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName: rName,
+				Config:       testNetworkResourceResource(rName, e2eNetworkID(), `example.com`, `null`, rName),
+				PlanOnly:     true,
+			},
+		},
+	})
+}
+
 func Test_NetworkResource_Update(t *testing.T) {
 	testE2E(t)
 	rName := "nre" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)

--- a/internal/provider/network_resource_resource.go
+++ b/internal/provider/network_resource_resource.go
@@ -8,18 +8,18 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
 	"github.com/netbirdio/netbird/shared/management/http/api"
@@ -94,9 +94,10 @@ func (r *NetworkResource) Schema(ctx context.Context, req resource.SchemaRequest
 			},
 			"groups": schema.SetAttribute{
 				MarkdownDescription: "Group IDs containing the resource",
-				Required:            true,
+				Optional:            true,
 				ElementType:         types.StringType,
-				Validators:          []validator.Set{setvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)), setvalidator.SizeAtLeast(1)},
+				Computed:            true,
+				Default:             setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
 			},
 		},
 	}

--- a/internal/provider/network_resource_test.go
+++ b/internal/provider/network_resource_test.go
@@ -123,7 +123,7 @@ func Test_NetworkResource_Create(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
-				Config:       testNetworkResourceResource(rName, "network1", `example.com`, `["group-notall", "group-all"]`, rName),
+				Config:       testNetworkResourceResource(rName, `example.com`, `["group-notall", "group-all"]`, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "address", "example.com"),
@@ -165,14 +165,31 @@ func Test_NetworkResource_Update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
-				Config:       testNetworkResourceResource(rName, "network1", `example.com`, `["group-notall"]`, rName),
+				Config:       testNetworkResourceResource(rName, `example.com`, `null`, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "groups.#", "0"),
 				),
 			},
 			{
 				ResourceName: rName,
-				Config:       testNetworkResourceResource(rName, "network1", `google.com`, `["group-all", "group-notall"]`, rName+"Updated"),
+				Config:       testNetworkResourceResource(rName, `example.com`, `["group-notall"]`, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "groups.#", "1"),
+				),
+			},
+			{
+				ResourceName: rName,
+				Config:       testNetworkResourceResource(rName, `example.com`, `[]`, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "groups.#", "0"),
+				),
+			},
+			{
+				ResourceName: rName,
+				Config:       testNetworkResourceResource(rName, `google.com`, `["group-all", "group-notall"]`, rName+"Updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(rNameFull, "address", "google.com"),
 					resource.TestCheckResourceAttr(rNameFull, "groups.#", "2"),
@@ -204,11 +221,11 @@ func Test_NetworkResource_Update(t *testing.T) {
 	})
 }
 
-func testNetworkResourceResource(rName, networkID, address, groups, name string) string {
+func testNetworkResourceResource(rName, address, groups, name string) string {
 	return fmt.Sprintf(`resource "netbird_network_resource" "%s" {
 	network_id = "%s"
 	address = "%s"
 	groups = %s
 	name = "%s"
-}`, rName, networkID, address, groups, name)
+}`, rName, "network1", address, groups, name)
 }


### PR DESCRIPTION
Hello 👋

Network resources can be created without associated group in the UI. This PR aim to replicate this possible behavior with the terraform provider.

- [x] Currently testing locally on my netbird resources.

Regards,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network resources can now be created without assigning groups.
  * Group assignments are optional and default to an empty set.
* **Bug Fixes**
  * Updating network resources now preserves provider configuration correctly.
* **Documentation**
  * Updated network resource documentation to improve the ordering and presentation of configuration fields.
* **Tests**
  * Added coverage confirming group-less resources are created successfully and produce no unnecessary plan changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->