### PR TITLE
fix: allow single-label match domains in nameserver_group

### DIFF
--- a/internal/provider/nameserver_group_acc_test.go
+++ b/internal/provider/nameserver_group_acc_test.go
@@ -5,6 +5,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -127,8 +129,84 @@ func Test_NameserverGroup_Update(t *testing.T) {
 	})
 }
 
+// Test_NameserverGroup_MatchDomains applies the match-domain shapes the domains
+// validator accepts. The unit test on fqdnRegex decides what the provider lets
+// through; only a deployment decides what management stores, and a domain the
+// provider accepts is a fix only if the server keeps it as written.
+//
+// Single-label domains are the reported bug (#145, #146): the regex demanded a
+// dot, so "lan" and "consul" never reached the API that accepts them. The rest of
+// the list is there for the round-trip rather than for the validator — management
+// stores a match domain verbatim, so the trailing dot and the mixed case have to
+// come back as they went in.
+//
+// That is what the step's own post-apply plan asserts, and it is the assertion
+// that matters most here: a value the server normalised on write would return
+// changed and diff on every plan afterwards, which surfaces as a non-empty plan
+// rather than as a failed check.
+func Test_NameserverGroup_MatchDomains(t *testing.T) {
+	testE2E(t)
+	rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_nameserver_group." + rName
+	domains := []string{"lan", "consul", "home.example.com", "trail.example.com.", "MiXeD.example.com", "123.eks.internal"}
+	var createdID string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().DNS.GetNameserverGroup, &createdID),
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       testNameserverGroupMatchDomains(rName, domains),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
+					// primary is unset in the configuration: a group with match
+					// domains cannot also resolve everything.
+					resource.TestCheckResourceAttr(rNameFull, "primary", "false"),
+					resource.TestCheckResourceAttr(rNameFull, "domains.#", fmt.Sprintf("%d", len(domains))),
+					func(s *terraform.State) error {
+						gID := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]
+						nsGroup, err := testClient().DNS.GetNameserverGroup(context.Background(), gID)
+						if err != nil {
+							return err
+						}
+						if !slices.Equal(nsGroup.Domains, domains) {
+							return fmt.Errorf("NameserverGroup Domains mismatch, expected %v, found %v on management server", domains, nsGroup.Domains)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // ns_type is always "udp": it is the schema default and the only transport the
 // nameserver API accepts today.
+
+func testNameserverGroupMatchDomains(rName string, domains []string) string {
+	quoted := make([]string, len(domains))
+	for i, d := range domains {
+		quoted[i] = fmt.Sprintf("%q", d)
+	}
+	return fmt.Sprintf(`resource "netbird_nameserver_group" "%[1]s" {
+	name = "%[1]s"
+	domains = [%[2]s]
+	nameservers = [
+		{
+			ip = "1.1.1.1"
+			ns_type = "udp"
+			port = 53
+		}
+	]
+	groups = [%[3]q]
+}`, rName, strings.Join(quoted, ", "), e2eGroupAllID())
+}
 
 func testNameserverGroupResource(rName, ip, port, groups string) string {
 	return fmt.Sprintf(`resource "netbird_nameserver_group" "%s" {

--- a/internal/provider/nameserver_group_resource.go
+++ b/internal/provider/nameserver_group_resource.go
@@ -30,7 +30,17 @@ import (
 )
 
 const (
-	fqdnRegex = `^(?:[_a-z0-9](?:[_a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?)?$`
+	// The management API's own domainRegex (netbirdio/netbird
+	// shared/management/domain/validate.go), copied verbatim — redundant
+	// (?:xn--)? branch included — so an upstream change is a textual diff here.
+	// It accepts a single label, which the regex it replaces did not: #145, #146.
+	//
+	// Two differences, both from what management's validateDomain does around that
+	// regex for a match domain: no (?:\*\.)? prefix, because it refuses wildcards
+	// outright and the plan should fail rather than the apply; and a trailing dot
+	// is allowed, because it trims one before matching and stores the domain as
+	// written.
+	fqdnRegex = `^(?:(?:xn--)?[a-zA-Z0-9_](?:[a-zA-Z0-9-_]{0,61}[a-zA-Z0-9])?\.)*(?:xn--)?[a-zA-Z0-9](?:[a-zA-Z0-9-_]{0,61}[a-zA-Z0-9])?\.?$`
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.

--- a/internal/provider/nameserver_group_test.go
+++ b/internal/provider/nameserver_group_test.go
@@ -191,8 +191,27 @@ func Test_fqdnRegex(t *testing.T) {
 			expected: true,
 		},
 		{
+			// single-label domains are valid match domains: the management
+			// API accepts them (see #145 / #146), the provider must too
 			fqdn:     "test",
-			expected: false,
+			expected: true,
+		},
+		{
+			fqdn:     "lan",
+			expected: true,
+		},
+		{
+			fqdn:     "consul",
+			expected: true,
+		},
+		{
+			// leading digits: the shape of an EKS cluster endpoint, #146
+			fqdn:     "123.eks.internal",
+			expected: true,
+		},
+		{
+			fqdn:     "under_score.lan",
+			expected: true,
 		},
 		{
 			fqdn:     "company.internal",
@@ -203,7 +222,40 @@ func Test_fqdnRegex(t *testing.T) {
 			expected: true,
 		},
 		{
+			fqdn:     "xn--bcher-kva.example",
+			expected: true,
+		},
+		{
+			fqdn:     "UPPER.example",
+			expected: true,
+		},
+		{
 			fqdn:     "company,name.internal-dns",
+			expected: false,
+		},
+		{
+			fqdn:     "-bad",
+			expected: false,
+		},
+		{
+			fqdn:     "bad-",
+			expected: false,
+		},
+		{
+			// wildcards are not allowed in nameserver match domains
+			fqdn:     "*.lab",
+			expected: false,
+		},
+		{
+			fqdn:     "..",
+			expected: false,
+		},
+		{
+			fqdn:     ".",
+			expected: false,
+		},
+		{
+			fqdn:     "",
 			expected: false,
 		},
 	}

--- a/internal/provider/validation_acc_test.go
+++ b/internal/provider/validation_acc_test.go
@@ -28,10 +28,11 @@ import (
 
 // The shapes terraform-plugin-framework produces for the validators used here.
 var (
-	outOfRange = regexp.MustCompile(`(?s)value must be between|Invalid Attribute Value`)
-	wrongSize  = regexp.MustCompile(`(?s)list must contain|Invalid Attribute Value|Insufficient|Too few`)
-	tooLong    = regexp.MustCompile(`(?s)length must be|Invalid Attribute Value`)
-	conflicts  = regexp.MustCompile(`(?s)Invalid Attribute Combination|cannot be specified when`)
+	outOfRange    = regexp.MustCompile(`(?s)value must be between|Invalid Attribute Value`)
+	wrongSize     = regexp.MustCompile(`(?s)list must contain|Invalid Attribute Value|Insufficient|Too few`)
+	tooLong       = regexp.MustCompile(`(?s)length must be|Invalid Attribute Value`)
+	conflicts     = regexp.MustCompile(`(?s)Invalid Attribute Combination|cannot be specified when`)
+	invalidDomain = regexp.MustCompile(`(?s)Invalid domain name|Invalid Attribute Value`)
 )
 
 // Test_Rejects_MutuallyExclusiveAttributes covers the thirteen ConflictsWith
@@ -430,6 +431,50 @@ resource "netbird_setup_key" "%[1]s" {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			rejects(t, c.config, c.want)
+		})
+	}
+}
+
+// Test_Rejects_InvalidMatchDomains covers the other half of the match-domain
+// validator: Test_NameserverGroup_MatchDomains applies the shapes it accepts,
+// these are the ones it must keep refusing now that a single label is legal.
+//
+// The wildcard is the one the API would also refuse, and the only reason to check
+// it here rather than in the unit test: a wildcard is a valid domain elsewhere in
+// the product — a route and a network resource both take one — so the provider
+// refusing it for a nameserver is a choice about this resource, and the choice is
+// only worth anything if the plan fails before the request is made.
+func Test_Rejects_InvalidMatchDomains(t *testing.T) {
+	testE2E(t)
+	rName := "v" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	cases := []struct {
+		name   string
+		domain string
+	}{
+		{name: "wildcard prefix", domain: "*.lab"},
+		{name: "leading hyphen", domain: "-lab"},
+		{name: "trailing hyphen", domain: "lab-"},
+		{name: "comma", domain: "company,name.internal"},
+		{name: "bare dot", domain: "."},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rejects(t, fmt.Sprintf(`
+resource "netbird_nameserver_group" "%[1]s" {
+  name        = "%[1]s"
+  description = "rejection fixture"
+  enabled     = true
+  groups      = [%[2]q]
+  domains     = [%[3]q]
+
+  nameservers = [{
+    ip      = "1.1.1.1"
+    ns_type = "udp"
+    port    = 53
+  }]
+}`, rName, e2eGroupNotAllID(), c.domain), invalidDomain)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`netbird_nameserver_group` rejects single-label match domains (`lan`, `consul`, EKS cluster endpoints) with `Invalid domain name`. The management API and the dashboard accept them. Reported in #145 and #146.

## Root cause

`fqdnRegex` requires at least one dot: its first group is `(?:label\.)+`, so a bare label can never match.

## Fix

Use the API's own regex. `domainRegex` in [`shared/management/domain/validate.go`](https://github.com/netbirdio/netbird/blob/main/shared/management/domain/validate.go), copied verbatim, with two deliberate differences — both taken from what `validateDomain` in `management/server/nameserver.go` does around it for a match domain:

- **no `(?:\*\.)?` prefix** — management refuses wildcards outright, so the plan should fail rather than the apply
- **optional trailing dot kept** — management trims one before matching and stores the domain as written

One unit case flips on purpose: `{"test", false}` -> `true`. That is the bug.

## Testing

`Test_fqdnRegex` gains the shapes the fix is about: single label, leading digit (EKS), underscore, punycode, uppercase, wildcard, bare and double dot, empty.

Two acceptance tests on the harness, because what the API accepts can only be settled against a deployment:

- `Test_NameserverGroup_MatchDomains` applies `["lan", "consul", "home.example.com", "trail.example.com.", "MiXeD.example.com", "123.eks.internal"]` and requires management to store the list verbatim. The step's post-apply plan carries the rest: a value normalised on write would diff on every plan.
- `Test_Rejects_InvalidMatchDomains` is the `ExpectError` half — wildcard, leading and trailing hyphen, comma, bare dot — each failing the plan before a request is made.

```
--- PASS: Test_NameserverGroup_MatchDomains (4.62s)
--- PASS: Test_Rejects_InvalidMatchDomains (21.32s)
```

Rebased on main for the harness.

`dns_record` and `network_resource` have their own domain validators with potentially the same issue — left out of scope.

Fixes #145
Fixes #146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Nameserver match-domain validation now accepts valid single-label, uppercase, numeric-leading, punycode, underscore-containing, and trailing-dot domains.
  - Invalid wildcard, malformed, empty, and dot-only domains continue to be rejected.
  - Updating a nameserver group with an empty ID now correctly preserves provider metadata.

- **Tests**
  - Expanded coverage for valid and invalid match-domain formats.
  - Added end-to-end verification for domain storage, import, and configuration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->