### PR TITLE
1Add per-attempt timeout and idempotency-aware retries to the REST client

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,5 +40,7 @@ provider "netbird" {
 ### Optional
 
 - `management_url` (String) NetBird Management API URL, can be also set through NB_MANAGEMENT_URL Environment Variable, value defined in Terraform files takes precedence
+- `max_retries` (Number) Maximum number of retries for transient Management API failures (429, 5xx, and connection errors; 5xx and connection retries are limited to idempotent methods), can be also set through NB_MAX_RETRIES Environment Variable. Defaults to 4, set to 0 to disable retries.
+- `request_timeout` (Number) Per-attempt timeout in seconds for Management API requests, can be also set through NB_REQUEST_TIMEOUT Environment Variable. Defaults to 30.
 - `tenant_account` (String) Account ID to impersonate, can be also set through NB_ACCOUNT Environment Variable, value defined in Terraform files takes precedence
 - `token` (String, Sensitive) Admin PAT for NetBird Management Server, can be also set through NB_PAT Environment Variable, value defined in Terraform files takes precedence

--- a/internal/provider/httpclient.go
+++ b/internal/provider/httpclient.go
@@ -1,0 +1,181 @@
+// Copyright (c) HashiCorp, Inc.
+
+package provider
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// The upstream NetBird REST SDK defaults to http.DefaultClient (no timeout)
+// and performs a single Do() with no retries. Against a flaky management API
+// that means a stalled response blocks forever (hanging plan/apply), and
+// transient 429/5xx/connection errors fail the whole run. This transport adds
+// a per-attempt timeout plus bounded, idempotency-aware retries with backoff.
+type retryTransport struct {
+	inner         http.RoundTripper
+	maxRetries    int
+	perTryTimeout time.Duration
+	waitMin       time.Duration
+	waitMax       time.Duration
+}
+
+// newRetryingHTTPClient builds an *http.Client (satisfies the SDK's HttpClient
+// interface) backed by retryTransport. No client-level Timeout is set: each
+// attempt is bounded by perTryTimeout via context, so the retry budget is not
+// cut short by a single overall deadline.
+func newRetryingHTTPClient(perTryTimeout time.Duration, maxRetries int) *http.Client {
+	// Guard against a non-positive timeout, which would make every attempt
+	// expire immediately and trigger a retry storm. Callers normally enforce
+	// this (request_timeout >= 1), but keep the constructor safe on its own.
+	if perTryTimeout <= 0 {
+		perTryTimeout = defaultRequestTimeoutSeconds * time.Second
+	}
+	return &http.Client{
+		Transport: &retryTransport{
+			inner:         http.DefaultTransport,
+			maxRetries:    maxRetries,
+			perTryTimeout: perTryTimeout,
+			waitMin:       1 * time.Second,
+			waitMax:       15 * time.Second,
+		},
+	}
+}
+
+// idempotent reports whether a method is safe to retry after a 5xx or a
+// transport error. POST/PATCH are excluded: a request that succeeded
+// server-side but failed on the response could be double-applied (e.g. a
+// duplicate group/peer/setup-key) if retried.
+func idempotent(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPut, http.MethodDelete, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t *retryTransport) shouldRetry(method string, resp *http.Response, err error) bool {
+	if err != nil {
+		// Transport error or per-attempt timeout. 429 not reached here.
+		return idempotent(method)
+	}
+	if resp == nil {
+		return false
+	}
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		// Rate limited: the request was not processed, safe for any method.
+		return true
+	case resp.StatusCode >= 500 && resp.StatusCode <= 599:
+		return idempotent(method)
+	default:
+		return false
+	}
+}
+
+// backoff returns the wait before the next attempt: exponential (waitMin<<n)
+// capped at waitMax, with jitter. A Retry-After header (429/503) takes
+// precedence when present.
+func (t *retryTransport) backoff(attempt int, resp *http.Response) time.Duration {
+	if resp != nil {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.Atoi(ra); err == nil && secs >= 0 {
+				d := time.Duration(secs) * time.Second
+				if d > t.waitMax {
+					d = t.waitMax
+				}
+				return d
+			}
+		}
+	}
+	wait := t.waitMin << uint(attempt)
+	if wait <= 0 || wait > t.waitMax {
+		wait = t.waitMax
+	}
+	// Full jitter in [wait/2, wait].
+	half := wait / 2
+	return half + time.Duration(rand.Int63n(int64(half)+1))
+}
+
+func drain(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Buffer the body once so each attempt can replay it.
+	var bodyBytes []byte
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		bodyBytes = b
+	}
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; ; attempt++ {
+		attemptReq := req.Clone(req.Context())
+		if bodyBytes != nil {
+			attemptReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			attemptReq.ContentLength = int64(len(bodyBytes))
+		}
+
+		// Per-attempt timeout derived from the caller's context, so Terraform
+		// cancellation (Ctrl-C) still aborts immediately.
+		ctx, cancel := context.WithTimeout(req.Context(), t.perTryTimeout)
+		resp, err = t.inner.RoundTrip(attemptReq.WithContext(ctx))
+
+		retry := t.shouldRetry(attemptReq.Method, resp, err) &&
+			attempt < t.maxRetries &&
+			req.Context().Err() == nil // outer cancel/deadline -> stop
+
+		if !retry {
+			if err != nil {
+				cancel()
+				return nil, err
+			}
+			// Defer cancel until the caller closes the body, otherwise the
+			// per-attempt timer would abort an in-progress body read.
+			resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancel}
+			return resp, nil
+		}
+
+		// Retrying: free this attempt's resources, then wait.
+		drain(resp)
+		wait := t.backoff(attempt, resp)
+		cancel()
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-req.Context().Done():
+			timer.Stop()
+			return nil, req.Context().Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// cancelOnCloseBody ties the per-attempt context's cancel to body Close so the
+// context is released once the caller is done reading the response.
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
+}

--- a/internal/provider/httpclient_test.go
+++ b/internal/provider/httpclient_test.go
@@ -1,0 +1,112 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newRetryTestClient(maxRetries int, perTry time.Duration) *http.Client {
+	return &http.Client{
+		Transport: &retryTransport{
+			inner:         http.DefaultTransport,
+			maxRetries:    maxRetries,
+			perTryTimeout: perTry,
+			waitMin:       time.Millisecond,
+			waitMax:       5 * time.Millisecond,
+		},
+	}
+}
+
+func doReq(t *testing.T, c *http.Client, method, url string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), method, url, strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func TestRetry_GET5xxThenOK(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&n, 1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp := doReq(t, newRetryTestClient(3, 2*time.Second), http.MethodGet, srv.URL)
+	if resp == nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after retry, got %v", resp)
+	}
+	if got := atomic.LoadInt32(&n); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+}
+
+func TestRetry_POST5xxNotRetried(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	resp := doReq(t, newRetryTestClient(3, 2*time.Second), http.MethodPost, srv.URL)
+	if resp == nil || resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 returned, got %v", resp)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Fatalf("POST 5xx must not retry: expected 1 attempt, got %d", got)
+	}
+}
+
+func TestRetry_POST429Retried(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&n, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	resp := doReq(t, newRetryTestClient(3, 2*time.Second), http.MethodPost, srv.URL)
+	if resp == nil || resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201 after 429 retry, got %v", resp)
+	}
+	if got := atomic.LoadInt32(&n); got != 2 {
+		t.Fatalf("429 should retry (not processed): expected 2 attempts, got %d", got)
+	}
+}
+
+func TestRetry_PerAttemptTimeoutThenBounded(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&n, 1)
+		time.Sleep(200 * time.Millisecond) // exceeds per-attempt timeout
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp := doReq(t, newRetryTestClient(2, 30*time.Millisecond), http.MethodGet, srv.URL)
+	if resp != nil {
+		t.Fatalf("expected timeout error, got status %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&n); got != 3 { // 1 initial + 2 retries
+		t.Fatalf("expected 3 bounded attempts, got %d", got)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
@@ -16,6 +18,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
+)
+
+const (
+	defaultRequestTimeoutSeconds = 30
+	defaultMaxRetries            = 4
 )
 
 // Ensure NetBirdProvider satisfies various provider interfaces.
@@ -32,9 +39,11 @@ type NetBirdProvider struct {
 
 // NetBirdProviderModel describes the provider data model.
 type NetBirdProviderModel struct {
-	ManagementURL types.String `tfsdk:"management_url"`
-	Token         types.String `tfsdk:"token"`
-	TenantAccount types.String `tfsdk:"tenant_account"`
+	ManagementURL  types.String `tfsdk:"management_url"`
+	Token          types.String `tfsdk:"token"`
+	TenantAccount  types.String `tfsdk:"tenant_account"`
+	RequestTimeout types.Int64  `tfsdk:"request_timeout"`
+	MaxRetries     types.Int64  `tfsdk:"max_retries"`
 }
 
 func (p *NetBirdProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -59,8 +68,36 @@ func (p *NetBirdProvider) Schema(ctx context.Context, req provider.SchemaRequest
 				MarkdownDescription: "Account ID to impersonate, can be also set through NB_ACCOUNT Environment Variable, value defined in Terraform files takes precedence",
 				Optional:            true,
 			},
+			"request_timeout": schema.Int64Attribute{
+				MarkdownDescription: "Per-attempt timeout in seconds for Management API requests, can be also set through NB_REQUEST_TIMEOUT Environment Variable. Defaults to 30.",
+				Optional:            true,
+			},
+			"max_retries": schema.Int64Attribute{
+				MarkdownDescription: "Maximum number of retries for transient Management API failures (429, 5xx, and connection errors; 5xx and connection retries are limited to idempotent methods), can be also set through NB_MAX_RETRIES Environment Variable. Defaults to 4, set to 0 to disable retries.",
+				Optional:            true,
+			},
 		},
 	}
+}
+
+// intSetting resolves an optional int provider setting: explicit config value
+// wins, then the environment variable, then the supplied default. Values below
+// minVal (from either source) are rejected and fall back to the default.
+// minVal lets callers forbid nonsensical values, e.g. request_timeout must be
+// >= 1 (a 0 per-attempt timeout would expire immediately and cause a retry
+// storm), while max_retries allows 0 to disable retries.
+func intSetting(v types.Int64, envVar string, def, minVal int) int {
+	if !v.IsNull() && !v.IsUnknown() {
+		if n := int(v.ValueInt64()); n >= minVal {
+			return n
+		}
+	}
+	if s, ok := os.LookupEnv(envVar); ok {
+		if n, err := strconv.Atoi(s); err == nil && n >= minVal {
+			return n
+		}
+	}
+	return def
 }
 
 func (p *NetBirdProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
@@ -89,10 +126,16 @@ func (p *NetBirdProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// request_timeout must be >= 1s; max_retries may be 0 to disable retries.
+	requestTimeout := intSetting(data.RequestTimeout, "NB_REQUEST_TIMEOUT", defaultRequestTimeoutSeconds, 1)
+	maxRetries := intSetting(data.MaxRetries, "NB_MAX_RETRIES", defaultMaxRetries, 0)
+	httpClient := newRetryingHTTPClient(time.Duration(requestTimeout)*time.Second, maxRetries)
+
 	client := netbird.NewWithOptions(
 		netbird.WithManagementURL(managementURL),
 		netbird.WithPAT(token),
-		netbird.WithUserAgent(fmt.Sprintf("terraform-provider-netbird/%s Terraform/%s", p.version, req.TerraformVersion)))
+		netbird.WithUserAgent(fmt.Sprintf("terraform-provider-netbird/%s Terraform/%s", p.version, req.TerraformVersion)),
+		netbird.WithHttpClient(httpClient))
 	if !data.TenantAccount.IsNull() && !data.TenantAccount.IsUnknown() {
 		client = client.Impersonate(data.TenantAccount.ValueString())
 	} else if v, ok := os.LookupEnv("NB_ACCOUNT"); ok {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -152,9 +152,11 @@ func TestProviderUserAgent(t *testing.T) {
 	}
 	req.Config = tfsdk.Config{
 		Raw: tftypes.NewValue(configValue, map[string]tftypes.Value{
-			"management_url": tftypes.NewValue(tftypes.String, nil),
-			"token":          tftypes.NewValue(tftypes.String, nil),
-			"tenant_account": tftypes.NewValue(tftypes.String, nil),
+			"management_url":  tftypes.NewValue(tftypes.String, nil),
+			"token":           tftypes.NewValue(tftypes.String, nil),
+			"tenant_account":  tftypes.NewValue(tftypes.String, nil),
+			"request_timeout": tftypes.NewValue(tftypes.Number, nil),
+			"max_retries":     tftypes.NewValue(tftypes.Number, nil),
 		}),
 		Schema: schemaResp.Schema,
 	}

--- a/internal/provider/settings_test.go
+++ b/internal/provider/settings_test.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestIntSetting(t *testing.T) {
+	const env = "NB_TEST_INT_SETTING"
+	const def = 30
+
+	cases := []struct {
+		name   string
+		val    types.Int64
+		setEnv bool
+		env    string
+		min    int
+		want   int
+	}{
+		// min=0 (max_retries semantics): 0 is a valid value (disable retries).
+		{"config value wins", types.Int64Value(5), false, "", 0, 5},
+		{"config zero valid when min 0", types.Int64Value(0), true, "99", 0, 0},
+		{"negative config ignored, env used", types.Int64Value(-3), true, "9", 0, 9},
+		{"null config uses env", types.Int64Null(), true, "7", 0, 7},
+		{"unknown config uses env", types.Int64Unknown(), true, "8", 0, 8},
+		{"negative env falls back to default", types.Int64Null(), true, "-1", 0, def},
+		{"unparseable env falls back to default", types.Int64Null(), true, "abc", 0, def},
+		{"empty env falls back to default", types.Int64Null(), true, "", 0, def},
+		{"nothing set uses default", types.Int64Null(), false, "", 0, def},
+		// min=1 (request_timeout semantics): 0 is invalid and must not pass
+		// through as a 0s per-attempt timeout (would cause a retry storm).
+		{"config zero rejected when min 1", types.Int64Value(0), false, "", 1, def},
+		{"env zero rejected when min 1", types.Int64Null(), true, "0", 1, def},
+		{"config one allowed when min 1", types.Int64Value(1), false, "", 1, 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv(env, tc.env)
+			} else {
+				_ = os.Unsetenv(env)
+			}
+			if got := intSetting(tc.val, env, def, tc.min); got != tc.want {
+				t.Fatalf("intSetting(%v, env=%q, min=%d) = %d, want %d", tc.val, tc.env, tc.min, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewRetryingHTTPClientGuardsZeroTimeout verifies the constructor never
+// builds a transport with a non-positive perTryTimeout, which would expire
+// every attempt immediately and cause a retry storm.
+func TestNewRetryingHTTPClientGuardsZeroTimeout(t *testing.T) {
+	for _, d := range []time.Duration{0, -5 * time.Second} {
+		c := newRetryingHTTPClient(d, 4)
+		rt, ok := c.Transport.(*retryTransport)
+		if !ok {
+			t.Fatalf("unexpected transport type %T", c.Transport)
+		}
+		if rt.perTryTimeout <= 0 {
+			t.Fatalf("perTryTimeout = %v, want > 0", rt.perTryTimeout)
+		}
+	}
+}


### PR DESCRIPTION
The upstream SDK uses http.DefaultClient (no timeout) and a single Do() with no retries, so a stalled NetBird management API hangs plan/apply indefinitely, and transient 429/5xx/connection errors fail the whole run. The SDK also leaks the response body on its error path, which can wedge the connection pool after a burst of error responses.

- internal/provider/httpclient.go: retryTransport, an http.RoundTripper with a per-attempt context timeout and bounded exponential backoff. 429 retries any method; 5xx and transport/timeout errors retry only idempotent methods (GET/HEAD/PUT/DELETE/OPTIONS) to avoid duplicate POST/PATCH side effects. Drains+closes bodies between attempts, honors Retry-After, and stops on outer context cancellation.
- internal/provider/provider.go: pass the client via WithHttpClient(); new optional request_timeout (NB_REQUEST_TIMEOUT, default 30s) and max_retries (NB_MAX_RETRIES, default 4) provider settings.
- internal/provider/httpclient_test.go: retry-policy unit tests.
- internal/provider/settings_test.go: intSetting precedence tests (config > env > default, negative/invalid fallback).
- internal/provider/provider_test.go: include the two new attributes in TestProviderUserAgent's config so it matches the updated schema.
- docs/index.md: document request_timeout and max_retries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `max_retries` configuration option to control Management API retry behavior (default: 4, configurable via `NB_MAX_RETRIES`)
  * Added `request_timeout` configuration option to set per-attempt request timeout in seconds (default: 30, configurable via `NB_REQUEST_TIMEOUT`)

* **Documentation**
  * Updated provider documentation with new configuration parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->