### PR TITLE
fix(account_settings): handle invalid responses

### DIFF
--- a/internal/provider/account_settings_data_source.go
+++ b/internal/provider/account_settings_data_source.go
@@ -160,8 +160,6 @@ func (d *AccountSettingsDataSource) Read(ctx context.Context, req datasource.Rea
 	}
 
 	accounts, err := d.client.Accounts.List(ctx)
-	account := accounts[0]
-
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -172,7 +170,13 @@ func (d *AccountSettingsDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	resp.Diagnostics.Append(accountAPIToTerraform(ctx, &account, &data)...)
+	account, err := firstAccount(accounts)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting AccountSettings", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(accountAPIToTerraform(ctx, account, &data)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/account_settings_resource.go
+++ b/internal/provider/account_settings_resource.go
@@ -293,6 +293,14 @@ func accountTerraformToAPI(ctx context.Context, account *api.Account, data Accou
 	}
 }
 
+func firstAccount(accounts []api.Account) (*api.Account, error) {
+	if len(accounts) == 0 {
+		return nil, fmt.Errorf("no accounts returned by API")
+	}
+
+	return &accounts[0], nil
+}
+
 func (r *AccountSettings) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data AccountSettingsModel
 
@@ -309,7 +317,11 @@ func (r *AccountSettings) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	account := &accounts[0]
+	account, err := firstAccount(accounts)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting AccountSettings", err.Error())
+		return
+	}
 
 	updateRequest := accountTerraformToAPI(ctx, account, data)
 
@@ -340,8 +352,6 @@ func (r *AccountSettings) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	accounts, err := r.client.Accounts.List(ctx)
-	account := &accounts[0]
-
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -349,6 +359,12 @@ func (r *AccountSettings) Read(ctx context.Context, req resource.ReadRequest, re
 		} else {
 			resp.Diagnostics.AddError("Error getting AccountSettings", err.Error())
 		}
+		return
+	}
+
+	account, err := firstAccount(accounts)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting AccountSettings", err.Error())
 		return
 	}
 
@@ -382,7 +398,11 @@ func (r *AccountSettings) Update(ctx context.Context, req resource.UpdateRequest
 		resp.Diagnostics.AddError("Error getting AccountSettings", err.Error())
 		return
 	}
-	account := &accounts[0]
+	account, err := firstAccount(accounts)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting AccountSettings", err.Error())
+		return
+	}
 
 	updateRequest := accountTerraformToAPI(ctx, account, data)
 

--- a/internal/provider/account_settings_test.go
+++ b/internal/provider/account_settings_test.go
@@ -2,13 +2,298 @@ package provider
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	tfdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
 	"github.com/netbirdio/netbird/shared/management/http/api"
 )
+
+func Test_firstAccount(t *testing.T) {
+	t.Run("returns first account", func(t *testing.T) {
+		accounts := []api.Account{{Id: "first"}, {Id: "second"}}
+
+		account, err := firstAccount(accounts)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if account.Id != "first" {
+			t.Fatalf("Expected first account, got %q", account.Id)
+		}
+	})
+
+	t.Run("returns error for empty response", func(t *testing.T) {
+		account, err := firstAccount(nil)
+
+		if account != nil {
+			t.Fatalf("Expected no account, got %#v", account)
+		}
+		if err == nil || !strings.Contains(err.Error(), "no accounts returned") {
+			t.Fatalf("Expected empty response error, got %v", err)
+		}
+	})
+}
+
+func Test_AccountSettingsReadHandlesInvalidAccountResponses(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		response       string
+		expectedDetail string
+	}{
+		{
+			name:           "API error",
+			status:         http.StatusInternalServerError,
+			response:       `{"message":"internal error"}`,
+			expectedDetail: "internal error",
+		},
+		{
+			name:           "empty account list",
+			status:         http.StatusOK,
+			response:       `[]`,
+			expectedDetail: "no accounts returned by API",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			accountSettings := &AccountSettings{
+				client: netbird.New(server.URL, "test-token"),
+			}
+			schemaResponse := tfresource.SchemaResponse{}
+			accountSettings.Schema(context.Background(), tfresource.SchemaRequest{}, &schemaResponse)
+
+			state := tfsdk.State{Schema: schemaResponse.Schema}
+			diags := state.Set(context.Background(), &AccountSettingsModel{
+				Id:                       types.StringValue("account-id"),
+				JwtAllowGroups:           types.ListNull(types.StringType),
+				NetworkTrafficLogsGroups: types.ListNull(types.StringType),
+				PeerExposeGroups:         types.ListNull(types.StringType),
+			})
+			if diags.HasError() {
+				t.Fatalf("Failed to prepare resource state: %v", diags.Errors())
+			}
+
+			response := tfresource.ReadResponse{State: state}
+			accountSettings.Read(
+				context.Background(),
+				tfresource.ReadRequest{State: state},
+				&response,
+			)
+
+			if !response.Diagnostics.HasError() {
+				t.Fatal("Expected an error diagnostic")
+			}
+			if !strings.Contains(response.Diagnostics.Errors()[0].Detail(), tt.expectedDetail) {
+				t.Fatalf(
+					"Expected diagnostic containing %q, got %q",
+					tt.expectedDetail,
+					response.Diagnostics.Errors()[0].Detail(),
+				)
+			}
+		})
+	}
+}
+
+func Test_AccountSettingsCreateHandlesInvalidAccountResponses(t *testing.T) {
+	testAccountSettingsWriteHandlesInvalidAccountResponses(t, "Create")
+}
+
+func Test_AccountSettingsUpdateHandlesInvalidAccountResponses(t *testing.T) {
+	testAccountSettingsWriteHandlesInvalidAccountResponses(t, "Update")
+}
+
+func testAccountSettingsWriteHandlesInvalidAccountResponses(t *testing.T, operation string) {
+	t.Helper()
+
+	tests := []struct {
+		name           string
+		status         int
+		response       string
+		expectedDetail string
+	}{
+		{
+			name:           "API error",
+			status:         http.StatusInternalServerError,
+			response:       `{"message":"internal error"}`,
+			expectedDetail: "internal error",
+		},
+		{
+			name:           "empty account list",
+			status:         http.StatusOK,
+			response:       `[]`,
+			expectedDetail: "no accounts returned by API",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var updateRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					updateRequests.Add(1)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			accountSettings := &AccountSettings{
+				client: netbird.New(server.URL, "test-token"),
+			}
+			schemaResponse := tfresource.SchemaResponse{}
+			accountSettings.Schema(context.Background(), tfresource.SchemaRequest{}, &schemaResponse)
+
+			plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+			diags := plan.Set(context.Background(), &AccountSettingsModel{
+				Id:                       types.StringValue("account-id"),
+				JwtAllowGroups:           types.ListNull(types.StringType),
+				NetworkTrafficLogsGroups: types.ListNull(types.StringType),
+				PeerExposeGroups:         types.ListNull(types.StringType),
+			})
+			if diags.HasError() {
+				t.Fatalf("Failed to prepare resource plan: %v", diags.Errors())
+			}
+
+			var diagnosticsError bool
+			var diagnosticDetail string
+			switch operation {
+			case "Create":
+				response := tfresource.CreateResponse{
+					State: tfsdk.State{Schema: schemaResponse.Schema},
+				}
+				accountSettings.Create(
+					context.Background(),
+					tfresource.CreateRequest{Plan: plan},
+					&response,
+				)
+				diagnosticsError = response.Diagnostics.HasError()
+				if diagnosticsError {
+					diagnosticDetail = response.Diagnostics.Errors()[0].Detail()
+				}
+			case "Update":
+				response := tfresource.UpdateResponse{
+					State: tfsdk.State{Schema: schemaResponse.Schema},
+				}
+				accountSettings.Update(
+					context.Background(),
+					tfresource.UpdateRequest{Plan: plan},
+					&response,
+				)
+				diagnosticsError = response.Diagnostics.HasError()
+				if diagnosticsError {
+					diagnosticDetail = response.Diagnostics.Errors()[0].Detail()
+				}
+			default:
+				t.Fatalf("Unsupported operation %q", operation)
+			}
+
+			if !diagnosticsError {
+				t.Fatal("Expected an error diagnostic")
+			}
+			if !strings.Contains(diagnosticDetail, tt.expectedDetail) {
+				t.Fatalf(
+					"Expected diagnostic containing %q, got %q",
+					tt.expectedDetail,
+					diagnosticDetail,
+				)
+			}
+			if got := updateRequests.Load(); got != 0 {
+				t.Fatalf("Expected no account update request, got %d", got)
+			}
+		})
+	}
+}
+
+func Test_AccountSettingsDataSourceReadHandlesInvalidAccountResponses(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		response       string
+		expectedDetail string
+	}{
+		{
+			name:           "API error",
+			status:         http.StatusInternalServerError,
+			response:       `{"message":"internal error"}`,
+			expectedDetail: "internal error",
+		},
+		{
+			name:           "empty account list",
+			status:         http.StatusOK,
+			response:       `[]`,
+			expectedDetail: "no accounts returned by API",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			accountSettings := &AccountSettingsDataSource{
+				client: netbird.New(server.URL, "test-token"),
+			}
+			schemaResponse := tfdatasource.SchemaResponse{}
+			accountSettings.Schema(context.Background(), tfdatasource.SchemaRequest{}, &schemaResponse)
+
+			configValues := make(map[string]tftypes.Value, len(schemaResponse.Schema.Attributes))
+			for name, attribute := range schemaResponse.Schema.Attributes {
+				attributeType := attribute.GetType().TerraformType(context.Background())
+				configValues[name] = tftypes.NewValue(attributeType, nil)
+			}
+			config := tfsdk.Config{
+				Raw: tftypes.NewValue(
+					schemaResponse.Schema.Type().TerraformType(context.Background()),
+					configValues,
+				),
+				Schema: schemaResponse.Schema,
+			}
+			response := tfdatasource.ReadResponse{
+				State: tfsdk.State{Schema: schemaResponse.Schema},
+			}
+			accountSettings.Read(
+				context.Background(),
+				tfdatasource.ReadRequest{Config: config},
+				&response,
+			)
+
+			if !response.Diagnostics.HasError() {
+				t.Fatal("Expected an error diagnostic")
+			}
+			if !strings.Contains(response.Diagnostics.Errors()[0].Detail(), tt.expectedDetail) {
+				t.Fatalf(
+					"Expected diagnostic containing %q, got %q",
+					tt.expectedDetail,
+					response.Diagnostics.Errors()[0].Detail(),
+				)
+			}
+		})
+	}
+}
 
 func Test_accountAPIToTerraform(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary

- check account-list errors before accessing API responses
- return Terraform diagnostics when the API returns no accounts
- guard resource Create, Read, and Update plus data-source Read
- add HTTP-level regression tests for API errors and empty account lists
- verify failed Create/Update paths issue no update request

Closes #118.

## Test plan

- [x] `go test -count=1 ./...`
- [x] `go build ./...`
- [x] `golangci-lint run`
- [x] `make generate`
- [x] account-settings Create/Update acceptance tests
- [x] fork CI: Terraform 1.7 through 1.12

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/terraform-provider-netbird/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787027305&installation_id=146802194&pr_number=165&repository=netbirdio%2Fterraform-provider-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fterraform-provider-netbird%2Fpull%2F165&signature=90a218676f0e51dbe5b326cb91516711f097683b8af40b3fa9f7d130aee9489d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account settings handling when account information is unavailable or invalid.
  * Replaced unexpected failures with clear error diagnostics when no account is returned.
  * Prevented account settings create, read, and update operations from proceeding with invalid responses.

* **Tests**
  * Added coverage for empty and unsuccessful account responses across account settings operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->