### PR TITLE
Add allow_match to reverse proxy access restrictions

### DIFF
--- a/docs/data-sources/reverse_proxy_service.md
+++ b/docs/data-sources/reverse_proxy_service.md
@@ -56,6 +56,7 @@ data "netbird_reverse_proxy_service" "by_id" {
 
 Read-Only:
 
+- `allow_match` (String) How the allowlists (allowed_cidrs, allowed_countries) combine: `all` (default) requires matching every configured allowlist (AND); `any` requires matching at least one (OR). Blocklists always reject on match regardless of this setting.
 - `allowed_cidrs` (List of String) CIDR allowlist
 - `allowed_countries` (List of String) ISO 3166-1 alpha-2 country codes to allow
 - `blocked_cidrs` (List of String) CIDR blocklist

--- a/docs/resources/reverse_proxy_service.md
+++ b/docs/resources/reverse_proxy_service.md
@@ -115,6 +115,9 @@ resource "netbird_reverse_proxy_service" "api_gateway" {
   access_restrictions = {
     allowed_countries = ["US", "DE", "GB"]
     blocked_cidrs     = ["192.168.0.0/16"]
+    # "any": allow a client matching an allowed country OR an allowed CIDR.
+    # "all" (default) requires matching every configured allowlist.
+    allow_match = "any"
   }
 }
 
@@ -269,6 +272,7 @@ Optional:
 
 Optional:
 
+- `allow_match` (String) How the allowlists (allowed_cidrs, allowed_countries) combine: `all` (default) requires matching every configured allowlist (AND); `any` requires matching at least one (OR). Blocklists always reject on match regardless of this setting.
 - `allowed_cidrs` (List of String) CIDR allowlist
 - `allowed_countries` (List of String) ISO 3166-1 alpha-2 country codes to allow
 - `blocked_cidrs` (List of String) CIDR blocklist

--- a/examples/resources/netbird_reverse_proxy_service/resource.tf
+++ b/examples/resources/netbird_reverse_proxy_service/resource.tf
@@ -100,6 +100,9 @@ resource "netbird_reverse_proxy_service" "api_gateway" {
   access_restrictions = {
     allowed_countries = ["US", "DE", "GB"]
     blocked_cidrs     = ["192.168.0.0/16"]
+    # "any": allow a client matching an allowed country OR an allowed CIDR.
+    # "all" (default) requires matching every configured allowlist.
+    allow_match = "any"
   }
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/netbirdio/netbird v0.77.1-0.20260818164913-ecfbd686b807
+	github.com/netbirdio/netbird v0.77.1-0.20260819085940-2355d4947d15
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/netbirdio/dex/api/v2 v2.0.0-20260512110716-8d70ad8647c1 h1:neE7z+FPUk
 github.com/netbirdio/dex/api/v2 v2.0.0-20260512110716-8d70ad8647c1/go.mod h1:awuTyT29CYALpEyET0S307EgNlPWrc7fFKRAyhsO45M=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42 h1:F3zS5fT9xzD1OFLfcdAE+3FfyiwjGukF1hvj0jErgs8=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42/go.mod h1:n47r67ZSPgwSmT/Z1o48JjZQW9YJ6m/6Bd/uAXkL3Pg=
-github.com/netbirdio/netbird v0.77.1-0.20260818164913-ecfbd686b807 h1:yl/D1KI0ptM5VtQxxmOBG8ic8m71PDPXQNS5BZDZj3U=
-github.com/netbirdio/netbird v0.77.1-0.20260818164913-ecfbd686b807/go.mod h1:kr9x8L43LCAwK1xUwLoc6M4sQgaErfLqV45p5KrCcnM=
+github.com/netbirdio/netbird v0.77.1-0.20260819085940-2355d4947d15 h1:B/sjipYxt9SDYDAgaB+o3E3AwwQXYCuhF3hMnP2L88M=
+github.com/netbirdio/netbird v0.77.1-0.20260819085940-2355d4947d15/go.mod h1:kr9x8L43LCAwK1xUwLoc6M4sQgaErfLqV45p5KrCcnM=
 github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oapi-codegen/runtime v1.6.0 h1:7Xx+GlueD6nRuyKoCPzL434Jfi3BetbiJOrzCHp/VPU=

--- a/internal/provider/reverse_proxy_acc_test.go
+++ b/internal/provider/reverse_proxy_acc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/netbirdio/netbird/shared/management/http/api"
 )
 
 func Test_ReverseProxyClusters_DataSource(t *testing.T) {
@@ -846,6 +847,7 @@ func Test_ReverseProxyService_AccessRestrictions(t *testing.T) {
 					resource.TestCheckResourceAttr(rNameFull, "access_restrictions.allowed_countries.1", "DE"),
 					resource.TestCheckResourceAttr(rNameFull, "access_restrictions.blocked_cidrs.#", "1"),
 					resource.TestCheckResourceAttr(rNameFull, "access_restrictions.blocked_cidrs.0", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(rNameFull, "access_restrictions.allow_match", "any"),
 					func(s *terraform.State) error {
 						id := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]
 						svc, err := testClient().ReverseProxyServices.Get(context.Background(), id)
@@ -860,6 +862,9 @@ func Test_ReverseProxyService_AccessRestrictions(t *testing.T) {
 						}
 						if svc.AccessRestrictions.BlockedCidrs == nil || len(*svc.AccessRestrictions.BlockedCidrs) != 1 {
 							return fmt.Errorf("expected 1 blocked CIDR")
+						}
+						if svc.AccessRestrictions.AllowMatch == nil || *svc.AccessRestrictions.AllowMatch != api.AccessRestrictionsAllowMatchAny {
+							return fmt.Errorf("expected allow_match any")
 						}
 						return nil
 					},
@@ -921,6 +926,7 @@ resource "netbird_reverse_proxy_service" "%s" {
   access_restrictions = {
     allowed_countries = ["US", "DE"]
     blocked_cidrs     = ["192.168.0.0/16"]
+    allow_match       = "any"
   }
 }`, rName, rName, domain, peerID)
 }

--- a/internal/provider/reverse_proxy_service_data_source.go
+++ b/internal/provider/reverse_proxy_service_data_source.go
@@ -256,6 +256,10 @@ func (d *ReverseProxyServiceDataSource) Schema(ctx context.Context, req datasour
 						Computed:            true,
 						ElementType:         types.StringType,
 					},
+					"allow_match": schema.StringAttribute{
+						MarkdownDescription: "How the allowlists (allowed_cidrs, allowed_countries) combine: `all` (default) requires matching every configured allowlist (AND); `any` requires matching at least one (OR). Blocklists always reject on match regardless of this setting.",
+						Computed:            true,
+					},
 				},
 			},
 		},

--- a/internal/provider/reverse_proxy_service_resource.go
+++ b/internal/provider/reverse_proxy_service_resource.go
@@ -208,10 +208,11 @@ func (m ReverseProxyHeaderAuthModel) TFType() types.ObjectType {
 
 // ReverseProxyAccessRestrictionsModel describes access restrictions.
 type ReverseProxyAccessRestrictionsModel struct {
-	AllowedCidrs     types.List `tfsdk:"allowed_cidrs"`
-	BlockedCidrs     types.List `tfsdk:"blocked_cidrs"`
-	AllowedCountries types.List `tfsdk:"allowed_countries"`
-	BlockedCountries types.List `tfsdk:"blocked_countries"`
+	AllowedCidrs     types.List   `tfsdk:"allowed_cidrs"`
+	BlockedCidrs     types.List   `tfsdk:"blocked_cidrs"`
+	AllowedCountries types.List   `tfsdk:"allowed_countries"`
+	BlockedCountries types.List   `tfsdk:"blocked_countries"`
+	AllowMatch       types.String `tfsdk:"allow_match"`
 }
 
 // TFType returns the Terraform object type for access restrictions.
@@ -222,6 +223,7 @@ func (m ReverseProxyAccessRestrictionsModel) TFType() types.ObjectType {
 			"blocked_cidrs":     types.ListType{ElemType: types.StringType},
 			"allowed_countries": types.ListType{ElemType: types.StringType},
 			"blocked_countries": types.ListType{ElemType: types.StringType},
+			"allow_match":       types.StringType,
 		},
 	}
 }
@@ -462,6 +464,11 @@ func (r *ReverseProxyService) Schema(ctx context.Context, req resource.SchemaReq
 						MarkdownDescription: "ISO 3166-1 alpha-2 country codes to block",
 						Optional:            true,
 						ElementType:         types.StringType,
+					},
+					"allow_match": schema.StringAttribute{
+						MarkdownDescription: "How the allowlists (allowed_cidrs, allowed_countries) combine: `all` (default) requires matching every configured allowlist (AND); `any` requires matching at least one (OR). Blocklists always reject on match regardless of this setting.",
+						Optional:            true,
+						Validators:          []validator.String{stringvalidator.OneOf("all", "any")},
 					},
 				},
 			},
@@ -734,6 +741,11 @@ func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, da
 			ret.Append(d...)
 		} else {
 			arModel.BlockedCountries = types.ListNull(types.StringType)
+		}
+		if svc.AccessRestrictions.AllowMatch != nil {
+			arModel.AllowMatch = types.StringValue(string(*svc.AccessRestrictions.AllowMatch))
+		} else {
+			arModel.AllowMatch = types.StringNull()
 		}
 		data.AccessRestrictions, d = types.ObjectValueFrom(ctx, ReverseProxyAccessRestrictionsModel{}.TFType().AttrTypes, arModel)
 		ret.Append(d...)
@@ -1010,6 +1022,11 @@ func reverseProxyServiceTerraformToAPI(ctx context.Context, data *ReverseProxySe
 			var countries []string
 			ret.Append(v.ElementsAs(ctx, &countries, false)...)
 			ar.BlockedCountries = &countries
+			hasAR = true
+		}
+		if v, ok := arAttrs["allow_match"].(types.String); ok && !v.IsNull() && !v.IsUnknown() {
+			m := api.AccessRestrictionsAllowMatch(v.ValueString())
+			ar.AllowMatch = &m
 			hasAR = true
 		}
 		if hasAR {


### PR DESCRIPTION
Adds the `allow_match` field to reverse proxy `access_restrictions`, exposing how the allowlists (allowed CIDRs, allowed countries) combine: `all` (default) requires matching every configured allowlist, `any` requires matching at least one. Blocklists are unaffected and always reject on match.

- Add `allow_match` to the resource and data source schema, model, and API mapping
- Extend the access restrictions acceptance test to cover `allow_match`
- Add the field to the generated docs and the resource example

Stacked on #133 (reverse-proxy-auth), which introduces `access_restrictions`.

Notes:
- The netbird dependency is temporarily pinned to the unreleased commit that adds `allow_match` to the API (netbirdio/netbird#6887), plus the matching dex `replace` directives. Re-pin to a tagged release once that merges and is released.
- Acceptance tests run against `netbirdio/management:latest` / `reverse-proxy:latest`, which do not yet include this feature, so they fail until a management/proxy image built from #6887 is available. Run the test workflow with the `management_image` / `proxy_image` inputs pointing at such a build to validate end to end.
