### PR TITLE
Add appsec_mode to reverse proxy access restrictions

### DIFF
--- a/docs/data-sources/reverse_proxy_service.md
+++ b/docs/data-sources/reverse_proxy_service.md
@@ -59,6 +59,7 @@ Read-Only:
 - `allow_match` (String) How the allowlists (allowed_cidrs, allowed_countries) combine: `all` (default) requires matching every configured allowlist (AND); `any` requires matching at least one (OR). Blocklists always reject on match regardless of this setting.
 - `allowed_cidrs` (List of String) CIDR allowlist
 - `allowed_countries` (List of String) ISO 3166-1 alpha-2 country codes to allow
+- `appsec_mode` (String) CrowdSec AppSec (WAF) request inspection mode: `off`, `enforce`, or `observe`. HTTP services only.
 - `blocked_cidrs` (List of String) CIDR blocklist
 - `blocked_countries` (List of String) ISO 3166-1 alpha-2 country codes to block
 

--- a/docs/resources/reverse_proxy_service.md
+++ b/docs/resources/reverse_proxy_service.md
@@ -118,6 +118,11 @@ resource "netbird_reverse_proxy_service" "api_gateway" {
     # "any": allow a client matching an allowed country OR an allowed CIDR.
     # "all" (default) requires matching every configured allowlist.
     allow_match = "any"
+    # CrowdSec AppSec (WAF) inspection. "observe" records verdicts in the
+    # access log without blocking, which is the safe way to evaluate the
+    # rules before switching to "enforce". Requires the proxy cluster to
+    # have an AppSec endpoint configured.
+    appsec_mode = "observe"
   }
 }
 
@@ -275,5 +280,6 @@ Optional:
 - `allow_match` (String) How the allowlists (allowed_cidrs, allowed_countries) combine: `all` (default) requires matching every configured allowlist (AND); `any` requires matching at least one (OR). Blocklists always reject on match regardless of this setting.
 - `allowed_cidrs` (List of String) CIDR allowlist
 - `allowed_countries` (List of String) ISO 3166-1 alpha-2 country codes to allow
+- `appsec_mode` (String) CrowdSec AppSec (WAF) request inspection mode: `off` (default), `enforce` to block requests the WAF flags, or `observe` to record verdicts in the access log without blocking. HTTP services only, and requires the proxy cluster to have a CrowdSec AppSec endpoint configured.
 - `blocked_cidrs` (List of String) CIDR blocklist
 - `blocked_countries` (List of String) ISO 3166-1 alpha-2 country codes to block

--- a/examples/resources/netbird_reverse_proxy_service/resource.tf
+++ b/examples/resources/netbird_reverse_proxy_service/resource.tf
@@ -103,6 +103,11 @@ resource "netbird_reverse_proxy_service" "api_gateway" {
     # "any": allow a client matching an allowed country OR an allowed CIDR.
     # "all" (default) requires matching every configured allowlist.
     allow_match = "any"
+    # CrowdSec AppSec (WAF) inspection. "observe" records verdicts in the
+    # access log without blocking, which is the safe way to evaluate the
+    # rules before switching to "enforce". Requires the proxy cluster to
+    # have an AppSec endpoint configured.
+    appsec_mode = "observe"
   }
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/netbirdio/netbird v0.77.1-0.20260819085940-2355d4947d15
+	github.com/netbirdio/netbird v0.77.1-0.20260819100030-5885fccb55ef
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,8 @@ github.com/netbirdio/dex/api/v2 v2.0.0-20260512110716-8d70ad8647c1 h1:neE7z+FPUk
 github.com/netbirdio/dex/api/v2 v2.0.0-20260512110716-8d70ad8647c1/go.mod h1:awuTyT29CYALpEyET0S307EgNlPWrc7fFKRAyhsO45M=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42 h1:F3zS5fT9xzD1OFLfcdAE+3FfyiwjGukF1hvj0jErgs8=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42/go.mod h1:n47r67ZSPgwSmT/Z1o48JjZQW9YJ6m/6Bd/uAXkL3Pg=
-github.com/netbirdio/netbird v0.77.1-0.20260819085940-2355d4947d15 h1:B/sjipYxt9SDYDAgaB+o3E3AwwQXYCuhF3hMnP2L88M=
-github.com/netbirdio/netbird v0.77.1-0.20260819085940-2355d4947d15/go.mod h1:kr9x8L43LCAwK1xUwLoc6M4sQgaErfLqV45p5KrCcnM=
+github.com/netbirdio/netbird v0.77.1-0.20260819100030-5885fccb55ef h1:2dKNhfrxeEJ24Zt/b6HHLBLrjSMBNNSHRjzmQU3wJQk=
+github.com/netbirdio/netbird v0.77.1-0.20260819100030-5885fccb55ef/go.mod h1:kr9x8L43LCAwK1xUwLoc6M4sQgaErfLqV45p5KrCcnM=
 github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oapi-codegen/runtime v1.6.0 h1:7Xx+GlueD6nRuyKoCPzL434Jfi3BetbiJOrzCHp/VPU=

--- a/internal/provider/reverse_proxy_acc_test.go
+++ b/internal/provider/reverse_proxy_acc_test.go
@@ -848,6 +848,7 @@ func Test_ReverseProxyService_AccessRestrictions(t *testing.T) {
 					resource.TestCheckResourceAttr(rNameFull, "access_restrictions.blocked_cidrs.#", "1"),
 					resource.TestCheckResourceAttr(rNameFull, "access_restrictions.blocked_cidrs.0", "192.168.0.0/16"),
 					resource.TestCheckResourceAttr(rNameFull, "access_restrictions.allow_match", "any"),
+					resource.TestCheckResourceAttr(rNameFull, "access_restrictions.appsec_mode", "observe"),
 					func(s *terraform.State) error {
 						id := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]
 						svc, err := testClient().ReverseProxyServices.Get(context.Background(), id)
@@ -865,6 +866,9 @@ func Test_ReverseProxyService_AccessRestrictions(t *testing.T) {
 						}
 						if svc.AccessRestrictions.AllowMatch == nil || *svc.AccessRestrictions.AllowMatch != api.AccessRestrictionsAllowMatchAny {
 							return fmt.Errorf("expected allow_match any")
+						}
+						if svc.AccessRestrictions.AppsecMode == nil || *svc.AccessRestrictions.AppsecMode != api.AccessRestrictionsAppsecModeObserve {
+							return fmt.Errorf("expected appsec_mode observe")
 						}
 						return nil
 					},
@@ -927,6 +931,7 @@ resource "netbird_reverse_proxy_service" "%s" {
     allowed_countries = ["US", "DE"]
     blocked_cidrs     = ["192.168.0.0/16"]
     allow_match       = "any"
+    appsec_mode       = "observe"
   }
 }`, rName, rName, domain, peerID)
 }

--- a/internal/provider/reverse_proxy_service_data_source.go
+++ b/internal/provider/reverse_proxy_service_data_source.go
@@ -260,6 +260,10 @@ func (d *ReverseProxyServiceDataSource) Schema(ctx context.Context, req datasour
 						MarkdownDescription: "How the allowlists (allowed_cidrs, allowed_countries) combine: `all` (default) requires matching every configured allowlist (AND); `any` requires matching at least one (OR). Blocklists always reject on match regardless of this setting.",
 						Computed:            true,
 					},
+					"appsec_mode": schema.StringAttribute{
+						MarkdownDescription: "CrowdSec AppSec (WAF) request inspection mode: `off`, `enforce`, or `observe`. HTTP services only.",
+						Computed:            true,
+					},
 				},
 			},
 		},

--- a/internal/provider/reverse_proxy_service_resource.go
+++ b/internal/provider/reverse_proxy_service_resource.go
@@ -213,6 +213,7 @@ type ReverseProxyAccessRestrictionsModel struct {
 	AllowedCountries types.List   `tfsdk:"allowed_countries"`
 	BlockedCountries types.List   `tfsdk:"blocked_countries"`
 	AllowMatch       types.String `tfsdk:"allow_match"`
+	AppsecMode       types.String `tfsdk:"appsec_mode"`
 }
 
 // TFType returns the Terraform object type for access restrictions.
@@ -224,6 +225,7 @@ func (m ReverseProxyAccessRestrictionsModel) TFType() types.ObjectType {
 			"allowed_countries": types.ListType{ElemType: types.StringType},
 			"blocked_countries": types.ListType{ElemType: types.StringType},
 			"allow_match":       types.StringType,
+			"appsec_mode":       types.StringType,
 		},
 	}
 }
@@ -469,6 +471,11 @@ func (r *ReverseProxyService) Schema(ctx context.Context, req resource.SchemaReq
 						MarkdownDescription: "How the allowlists (allowed_cidrs, allowed_countries) combine: `all` (default) requires matching every configured allowlist (AND); `any` requires matching at least one (OR). Blocklists always reject on match regardless of this setting.",
 						Optional:            true,
 						Validators:          []validator.String{stringvalidator.OneOf("all", "any")},
+					},
+					"appsec_mode": schema.StringAttribute{
+						MarkdownDescription: "CrowdSec AppSec (WAF) request inspection mode: `off` (default), `enforce` to block requests the WAF flags, or `observe` to record verdicts in the access log without blocking. HTTP services only, and requires the proxy cluster to have a CrowdSec AppSec endpoint configured.",
+						Optional:            true,
+						Validators:          []validator.String{stringvalidator.OneOf("off", "enforce", "observe")},
 					},
 				},
 			},
@@ -746,6 +753,11 @@ func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, da
 			arModel.AllowMatch = types.StringValue(string(*svc.AccessRestrictions.AllowMatch))
 		} else {
 			arModel.AllowMatch = types.StringNull()
+		}
+		if svc.AccessRestrictions.AppsecMode != nil {
+			arModel.AppsecMode = types.StringValue(string(*svc.AccessRestrictions.AppsecMode))
+		} else {
+			arModel.AppsecMode = types.StringNull()
 		}
 		data.AccessRestrictions, d = types.ObjectValueFrom(ctx, ReverseProxyAccessRestrictionsModel{}.TFType().AttrTypes, arModel)
 		ret.Append(d...)
@@ -1027,6 +1039,11 @@ func reverseProxyServiceTerraformToAPI(ctx context.Context, data *ReverseProxySe
 		if v, ok := arAttrs["allow_match"].(types.String); ok && !v.IsNull() && !v.IsUnknown() {
 			m := api.AccessRestrictionsAllowMatch(v.ValueString())
 			ar.AllowMatch = &m
+			hasAR = true
+		}
+		if v, ok := arAttrs["appsec_mode"].(types.String); ok && !v.IsNull() && !v.IsUnknown() {
+			m := api.AccessRestrictionsAppsecMode(v.ValueString())
+			ar.AppsecMode = &m
 			hasAR = true
 		}
 		if hasAR {

--- a/internal/provider/reverse_proxy_service_test.go
+++ b/internal/provider/reverse_proxy_service_test.go
@@ -1323,6 +1323,8 @@ func Test_reverseProxyServiceRoundtrip_accessRestrictions(t *testing.T) {
 		AccessRestrictions: &api.AccessRestrictions{
 			AllowedCountries: &[]string{"US", "DE"},
 			BlockedCidrs:     &[]string{"192.168.0.0/16", "10.0.0.0/8"},
+			AllowMatch:       valPtr(api.AccessRestrictionsAllowMatchAny),
+			AppsecMode:       valPtr(api.AccessRestrictionsAppsecModeEnforce),
 		},
 	}
 
@@ -1359,6 +1361,12 @@ func Test_reverseProxyServiceRoundtrip_accessRestrictions(t *testing.T) {
 	}
 	if req.AccessRestrictions.BlockedCountries != nil {
 		t.Error("BlockedCountries should be nil when not set")
+	}
+	if req.AccessRestrictions.AllowMatch == nil || *req.AccessRestrictions.AllowMatch != api.AccessRestrictionsAllowMatchAny {
+		t.Errorf("AllowMatch mismatch: got %v", req.AccessRestrictions.AllowMatch)
+	}
+	if req.AccessRestrictions.AppsecMode == nil || *req.AccessRestrictions.AppsecMode != api.AccessRestrictionsAppsecModeEnforce {
+		t.Errorf("AppsecMode mismatch: got %v", req.AccessRestrictions.AppsecMode)
 	}
 }
 
@@ -1397,4 +1405,47 @@ func mustObjectValue(ctx context.Context, attrTypes map[string]attr.Type, val an
 		panic("failed to create object value in test helper")
 	}
 	return obj
+}
+
+// appsec_mode alone must keep the access_restrictions object alive: unlike
+// allow_match it is meaningful without any CIDR or country entry.
+func Test_reverseProxyServiceRoundtrip_appsecModeOnly(t *testing.T) {
+	ctx := context.Background()
+
+	appsecMode := api.AccessRestrictionsAppsecModeObserve
+	original := &api.Service{
+		Id:      "svc-appsec-only",
+		Name:    "appsec-only-service",
+		Domain:  "appsec.example.com",
+		Enabled: true,
+		Targets: []api.ServiceTarget{
+			{
+				TargetId:   "peer1",
+				TargetType: api.ServiceTargetTargetTypePeer,
+				Port:       8080,
+				Protocol:   api.ServiceTargetProtocolHttp,
+				Enabled:    true,
+				Host:       valPtr("10.0.0.1"),
+			},
+		},
+		AccessRestrictions: &api.AccessRestrictions{AppsecMode: &appsecMode},
+	}
+
+	var model ReverseProxyServiceModel
+	d := reverseProxyServiceAPIToTerraform(ctx, original, &model)
+	if d.HasError() {
+		t.Fatalf("APIToTerraform failed with %d errors", d.ErrorsCount())
+	}
+
+	req, d := reverseProxyServiceTerraformToAPI(ctx, &model)
+	if d.HasError() {
+		t.Fatalf("TerraformToAPI failed with %d errors", d.ErrorsCount())
+	}
+
+	if req.AccessRestrictions == nil {
+		t.Fatal("appsec_mode alone must not collapse access_restrictions to nil")
+	}
+	if req.AccessRestrictions.AppsecMode == nil || *req.AccessRestrictions.AppsecMode != appsecMode {
+		t.Errorf("AppsecMode mismatch: got %v", req.AccessRestrictions.AppsecMode)
+	}
 }


### PR DESCRIPTION
Exposes the reverse proxy's CrowdSec AppSec (WAF) mode through the service resource and data source. Backend PR: netbirdio/netbird#6917.

- Add `appsec_mode` to the `access_restrictions` block on `netbird_reverse_proxy_service`, validated against off/enforce/observe
- Surface it as a computed attribute on the service data source
- Extend the example and the access-restrictions acceptance test, and add round-trip coverage for the conversion in both directions

The netbird dependency is pinned to a pre-merge commit of the backend branch; it needs re-pinning once that PR lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/terraform-provider-netbird/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787747079&installation_model_id=427504&pr_number=171&repository=netbirdio%2Fterraform-provider-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fterraform-provider-netbird%2Fpull%2F171&signature=4ecf80664b7e61e81b903cc966a4bcb2413ee182eb57b1bbbd0d3ce4c04fc33b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->