### PR TITLE
Fix agent-network bugs that silently destroy server-side state

### DIFF
--- a/docs/data-sources/agent_network_provider.md
+++ b/docs/data-sources/agent_network_provider.md
@@ -31,8 +31,10 @@ data "netbird_agent_network_provider" "openai" {
 - `api_key` (String, Sensitive) Not returned by the API (sealed at rest)
 - `bootstrap_cluster` (String) Bootstrap cluster (only relevant on create)
 - `enabled` (Boolean) Whether the provider is enabled
+- `extra_values` (Map of String) Catalog-specific extra header values
 - `identity_header_groups` (String) Wire header for caller groups
 - `identity_header_user_id` (String) Wire header for caller display identity
+- `metadata_disabled` (Boolean) Whether identity-metadata injection is suppressed for this provider
 - `models` (Attributes List) Models exposed through this endpoint (see [below for nested schema](#nestedatt--models))
 - `provider_id` (String) Catalog identifier for the upstream AI provider
 - `skip_tls_verification` (Boolean) Whether upstream TLS verification is skipped

--- a/docs/resources/agent_network_provider.md
+++ b/docs/resources/agent_network_provider.md
@@ -48,8 +48,10 @@ resource "netbird_agent_network_provider" "openai" {
 
 - `bootstrap_cluster` (String) Proxy cluster used when creating the first provider. Ignored on subsequent creates and all updates.
 - `enabled` (Boolean) Whether the provider is enabled
+- `extra_values` (Map of String) Catalog-specific extra header values (e.g. `x-portkey-config` for Portkey gateways). Omit to leave the stored values unchanged. Empty values are dropped by the API.
 - `identity_header_groups` (String) Wire header name the proxy stamps with the caller's NetBird groups as a comma-separated list
 - `identity_header_user_id` (String) Wire header name the proxy stamps with the caller's display identity
+- `metadata_disabled` (Boolean) Suppress identity-metadata injection for this provider (e.g. the AWS Bedrock request-metadata header). Omit to leave the stored value unchanged.
 - `models` (Attributes List) Models exposed through this endpoint with per-1k token prices. Empty means all catalog models at catalog prices. (see [below for nested schema](#nestedatt--models))
 - `skip_tls_verification` (Boolean) Skip upstream TLS certificate verification (for self-hosted gateways with private certificates)
 

--- a/docs/resources/agent_network_settings.md
+++ b/docs/resources/agent_network_settings.md
@@ -26,10 +26,10 @@ resource "netbird_agent_network_settings" "main" {
 
 ### Optional
 
-- `access_log_retention_days` (Number) Days to retain full access-log rows (0 or less = keep indefinitely)
-- `enable_log_collection` (Boolean) Collect per-request access-log entries for this account
-- `enable_prompt_collection` (Boolean) Master switch for request/response prompt capture (effective only when a policy guardrail also enables it)
-- `redact_pii` (Boolean) Redact PII from captured prompts
+- `access_log_retention_days` (Number) Days to retain full access-log rows (0 or less = keep indefinitely). Omit to leave the account's current value unchanged.
+- `enable_log_collection` (Boolean) Collect per-request access-log entries for this account. Omit to leave the account's current value unchanged.
+- `enable_prompt_collection` (Boolean) Master switch for request/response prompt capture (effective only when a policy guardrail also enables it). Omit to leave the account's current value unchanged.
+- `redact_pii` (Boolean) Redact PII from captured prompts. Omit to leave the account's current value unchanged.
 
 ### Read-Only
 

--- a/internal/provider/agent_network_client.go
+++ b/internal/provider/agent_network_client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
 
 	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
 	"github.com/netbirdio/netbird/shared/management/http/api"
@@ -164,11 +165,29 @@ func (a *agentNetworkClient) DeleteGuardrail(ctx context.Context, id string) err
 // ---- Settings ---------------------------------------------------------------
 
 func (a *agentNetworkClient) GetSettings(ctx context.Context) (*api.AgentNetworkSettings, error) {
-	r, err := anDo[api.AgentNetworkSettings](ctx, a.c, "GET", "/api/agent-network/settings", nil)
+	resp, err := a.c.NewRequest(ctx, "GET", "/api/agent-network/settings", nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &r, nil
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	// The server deliberately answers 200 with a JSON `null` body (not 404)
+	// when the account's agent-network settings row has not been bootstrapped.
+	// Decoding that would yield a bogus all-zero settings row, so translate it
+	// into a NotFound error and let callers treat the resource as absent.
+	if trimmed := bytes.TrimSpace(body); len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, &netbird.APIError{StatusCode: http.StatusNotFound, Message: "agent network settings not found"}
+	}
+	var result api.AgentNetworkSettings
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 func (a *agentNetworkClient) UpdateSettings(ctx context.Context, req api.PutApiAgentNetworkSettingsJSONRequestBody) (*api.AgentNetworkSettings, error) {

--- a/internal/provider/agent_network_client_test.go
+++ b/internal/provider/agent_network_client_test.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
+)
+
+// Body-less requests (every GET/DELETE) must not panic. Regression test for a
+// typed-nil *bytes.Reader being passed as the io.Reader body: as a non-nil
+// interface wrapping a nil pointer it made http.NewRequestWithContext
+// dereference the nil reader and panic on every Read/List/Delete.
+func Test_agentNetworkClient_bodylessRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Valid JSON for the GET decode path; ignored by DELETE.
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	client := newAgentNetworkClient(netbird.New(server.URL, "test-token"))
+	ctx := context.Background()
+
+	if _, err := client.ListProviders(ctx); err != nil {
+		t.Fatalf("ListProviders (body-less GET) returned error: %v", err)
+	}
+	if err := client.DeleteProvider(ctx, "some-id"); err != nil {
+		t.Fatalf("DeleteProvider (body-less DELETE) returned error: %v", err)
+	}
+}
+
+// The server deliberately answers 200 with a JSON `null` body (not 404) when the
+// account's agent-network settings row has not been bootstrapped. GetSettings
+// must report that as NotFound so Read removes the resource instead of writing
+// an all-zero settings row into state.
+func Test_agentNetworkClient_GetSettings(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         string
+		wantNotFound bool
+		wantCluster  string
+	}{
+		{name: "null body is not found", body: "null", wantNotFound: true},
+		{name: "empty body is not found", body: "", wantNotFound: true},
+		{
+			name:        "populated body decodes",
+			body:        `{"cluster":"c1","subdomain":"sub","endpoint":"sub.c1","enable_log_collection":true}`,
+			wantCluster: "c1",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(c.body))
+			}))
+			defer server.Close()
+
+			client := newAgentNetworkClient(netbird.New(server.URL, "test-token"))
+			s, err := client.GetSettings(context.Background())
+
+			if c.wantNotFound {
+				if err == nil {
+					t.Fatalf("Expected an error, got settings %+v", s)
+				}
+				if !netbird.IsNotFound(err) {
+					t.Fatalf("Expected netbird.IsNotFound(err), got: %v", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+			if s.Cluster != c.wantCluster {
+				t.Fatalf("Expected cluster %q, got %q", c.wantCluster, s.Cluster)
+			}
+		})
+	}
+}

--- a/internal/provider/agent_network_provider_data_source.go
+++ b/internal/provider/agent_network_provider_data_source.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
 	"github.com/netbirdio/netbird/shared/management/http/api"
 )
@@ -73,6 +74,15 @@ func (d *AgentNetworkProviderDataSource) Schema(_ context.Context, _ datasource.
 			"identity_header_groups": schema.StringAttribute{
 				MarkdownDescription: "Wire header for caller groups",
 				Computed:            true,
+			},
+			"metadata_disabled": schema.BoolAttribute{
+				MarkdownDescription: "Whether identity-metadata injection is suppressed for this provider",
+				Computed:            true,
+			},
+			"extra_values": schema.MapAttribute{
+				MarkdownDescription: "Catalog-specific extra header values",
+				Computed:            true,
+				ElementType:         types.StringType,
 			},
 			"models": schema.ListNestedAttribute{
 				MarkdownDescription: "Models exposed through this endpoint",

--- a/internal/provider/agent_network_provider_resource.go
+++ b/internal/provider/agent_network_provider_resource.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -42,6 +44,8 @@ type AgentNetworkProviderModel struct {
 	SkipTlsVerification  types.Bool   `tfsdk:"skip_tls_verification"`
 	IdentityHeaderUserId types.String `tfsdk:"identity_header_user_id"`
 	IdentityHeaderGroups types.String `tfsdk:"identity_header_groups"`
+	MetadataDisabled     types.Bool   `tfsdk:"metadata_disabled"`
+	ExtraValues          types.Map    `tfsdk:"extra_values"`
 	Models               types.List   `tfsdk:"models"`
 }
 
@@ -118,6 +122,19 @@ func (r *AgentNetworkProvider) Schema(_ context.Context, _ resource.SchemaReques
 				Computed:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
+			"metadata_disabled": schema.BoolAttribute{
+				MarkdownDescription: "Suppress identity-metadata injection for this provider (e.g. the AWS Bedrock request-metadata header). Omit to leave the stored value unchanged.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"extra_values": schema.MapAttribute{
+				MarkdownDescription: "Catalog-specific extra header values (e.g. `x-portkey-config` for Portkey gateways). Omit to leave the stored values unchanged. Empty values are dropped by the API.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				PlanModifiers:       []planmodifier.Map{mapplanmodifier.UseStateForUnknown()},
+			},
 			"models": schema.ListNestedAttribute{
 				MarkdownDescription: "Models exposed through this endpoint with per-1k token prices. Empty means all catalog models at catalog prices.",
 				Optional:            true,
@@ -156,6 +173,18 @@ func (r *AgentNetworkProvider) Configure(_ context.Context, req resource.Configu
 	r.client = newAgentNetworkClient(client)
 }
 
+// preserveConfiguredEmptyString keeps an explicitly-configured empty string
+// intact when the API omits the field. The identity-header fields treat "" as
+// "disable stamping for this dimension", but the server omits them from
+// responses when empty, which would turn a configured "" into null and trip
+// Terraform's "provider produced inconsistent result after apply" check.
+func preserveConfiguredEmptyString(apiVal *string, configured types.String) types.String {
+	if apiVal == nil && !configured.IsNull() && !configured.IsUnknown() && configured.ValueString() == "" {
+		return types.StringValue("")
+	}
+	return types.StringPointerValue(apiVal)
+}
+
 func agentNetworkProviderAPIToTerraform(ctx context.Context, p *api.AgentNetworkProvider, data *AgentNetworkProviderModel) diag.Diagnostics {
 	var ret diag.Diagnostics
 	data.Id = types.StringValue(p.Id)
@@ -164,8 +193,17 @@ func agentNetworkProviderAPIToTerraform(ctx context.Context, p *api.AgentNetwork
 	data.UpstreamUrl = types.StringValue(p.UpstreamUrl)
 	data.Enabled = types.BoolValue(p.Enabled)
 	data.SkipTlsVerification = types.BoolValue(p.SkipTlsVerification)
-	data.IdentityHeaderUserId = types.StringPointerValue(p.IdentityHeaderUserId)
-	data.IdentityHeaderGroups = types.StringPointerValue(p.IdentityHeaderGroups)
+	data.IdentityHeaderUserId = preserveConfiguredEmptyString(p.IdentityHeaderUserId, data.IdentityHeaderUserId)
+	data.IdentityHeaderGroups = preserveConfiguredEmptyString(p.IdentityHeaderGroups, data.IdentityHeaderGroups)
+	data.MetadataDisabled = types.BoolValue(p.MetadataDisabled)
+
+	if p.ExtraValues != nil {
+		m, d := types.MapValueFrom(ctx, types.StringType, *p.ExtraValues)
+		ret.Append(d...)
+		data.ExtraValues = m
+	} else {
+		data.ExtraValues = types.MapNull(types.StringType)
+	}
 
 	modelObjs := make([]AgentNetworkProviderModelItem, 0, len(p.Models))
 	for _, m := range p.Models {
@@ -201,6 +239,20 @@ func agentNetworkProviderTerraformToRequest(ctx context.Context, data *AgentNetw
 	}
 	if !data.IdentityHeaderGroups.IsNull() && !data.IdentityHeaderGroups.IsUnknown() {
 		req.IdentityHeaderGroups = data.IdentityHeaderGroups.ValueStringPointer()
+	}
+	// The server rebuilds the provider row from the request on update, carrying
+	// over only the API key and session keys. Anything omitted here is reset, so
+	// these must be sent whenever their value is known (UseStateForUnknown makes
+	// the prior value known on update) or they would be silently wiped.
+	if !data.MetadataDisabled.IsNull() && !data.MetadataDisabled.IsUnknown() {
+		req.MetadataDisabled = data.MetadataDisabled.ValueBoolPointer()
+	}
+	if !data.ExtraValues.IsNull() && !data.ExtraValues.IsUnknown() {
+		extra := make(map[string]string, len(data.ExtraValues.Elements()))
+		ret.Append(data.ExtraValues.ElementsAs(ctx, &extra, false)...)
+		if !ret.HasError() {
+			req.ExtraValues = &extra
+		}
 	}
 	if !data.Models.IsNull() && !data.Models.IsUnknown() {
 		var elems []AgentNetworkProviderModelItem

--- a/internal/provider/agent_network_provider_test.go
+++ b/internal/provider/agent_network_provider_test.go
@@ -1,0 +1,167 @@
+package provider
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+func Test_agentNetworkProviderAPIToTerraform(t *testing.T) {
+	cases := []struct {
+		resource *api.AgentNetworkProvider
+		expected AgentNetworkProviderModel
+	}{
+		{
+			resource: &api.AgentNetworkProvider{
+				Id:                  "p1",
+				ProviderId:          "openai_api",
+				Name:                "OpenAI",
+				UpstreamUrl:         "https://api.openai.com",
+				Enabled:             true,
+				SkipTlsVerification: false,
+				MetadataDisabled:    true,
+				ExtraValues:         &map[string]string{"x-portkey-config": "pc-abc123"},
+				Models: []api.AgentNetworkProviderModel{
+					{Id: "gpt-4o-mini", InputPer1k: 0.00015, OutputPer1k: 0.0006},
+				},
+			},
+			expected: AgentNetworkProviderModel{
+				Id:                  types.StringValue("p1"),
+				ProviderId:          types.StringValue("openai_api"),
+				Name:                types.StringValue("OpenAI"),
+				UpstreamUrl:         types.StringValue("https://api.openai.com"),
+				Enabled:             types.BoolValue(true),
+				SkipTlsVerification: types.BoolValue(false),
+				MetadataDisabled:    types.BoolValue(true),
+				ExtraValues: types.MapValueMust(types.StringType, map[string]attr.Value{
+					"x-portkey-config": types.StringValue("pc-abc123"),
+				}),
+				Models: types.ListValueMust(AgentNetworkProviderModelItem{}.TFType(), []attr.Value{
+					types.ObjectValueMust(AgentNetworkProviderModelItem{}.TFType().AttrTypes, map[string]attr.Value{
+						"id":            types.StringValue("gpt-4o-mini"),
+						"input_per_1k":  types.Float64Value(0.00015),
+						"output_per_1k": types.Float64Value(0.0006),
+					}),
+				}),
+			},
+		},
+		{
+			// No extra_values / identity headers in the response: extra_values
+			// becomes a null map, not an empty one.
+			resource: &api.AgentNetworkProvider{
+				Id:          "p2",
+				ProviderId:  "custom",
+				Name:        "Custom",
+				UpstreamUrl: "https://example.com",
+			},
+			expected: AgentNetworkProviderModel{
+				Id:                  types.StringValue("p2"),
+				ProviderId:          types.StringValue("custom"),
+				Name:                types.StringValue("Custom"),
+				UpstreamUrl:         types.StringValue("https://example.com"),
+				Enabled:             types.BoolValue(false),
+				MetadataDisabled:    types.BoolValue(false),
+				SkipTlsVerification: types.BoolValue(false),
+				ExtraValues:         types.MapNull(types.StringType),
+				Models:              types.ListValueMust(AgentNetworkProviderModelItem{}.TFType(), []attr.Value{}),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		var out AgentNetworkProviderModel
+		outDiag := agentNetworkProviderAPIToTerraform(context.Background(), c.resource, &out)
+		if outDiag.HasError() {
+			t.Fatalf("Expected no error diagnostics, found %d errors", outDiag.ErrorsCount())
+		}
+
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Expected:\n%#v\nFound:\n%#v", c.expected, out)
+		}
+	}
+}
+
+// An empty identity-header value means "disable stamping for this dimension",
+// but the API omits empty values from responses. Without preserving the
+// configured "" the apply would fail with "provider produced inconsistent
+// result after apply ... was cty.StringVal(\"\"), but now null".
+func Test_agentNetworkProviderAPIToTerraform_preservesEmptyIdentityHeaders(t *testing.T) {
+	out := AgentNetworkProviderModel{
+		IdentityHeaderUserId: types.StringValue(""),
+		IdentityHeaderGroups: types.StringValue(""),
+	}
+
+	res := &api.AgentNetworkProvider{Id: "p1", ProviderId: "custom", Name: "n", UpstreamUrl: "u"}
+	if d := agentNetworkProviderAPIToTerraform(context.Background(), res, &out); d.HasError() {
+		t.Fatalf("Expected no error diagnostics, found %d errors", d.ErrorsCount())
+	}
+
+	if out.IdentityHeaderUserId != types.StringValue("") {
+		t.Errorf("identity_header_user_id: expected preserved \"\", got %#v", out.IdentityHeaderUserId)
+	}
+	if out.IdentityHeaderGroups != types.StringValue("") {
+		t.Errorf("identity_header_groups: expected preserved \"\", got %#v", out.IdentityHeaderGroups)
+	}
+
+	// An unset (null) header must stay null rather than becoming "".
+	unset := AgentNetworkProviderModel{}
+	if d := agentNetworkProviderAPIToTerraform(context.Background(), res, &unset); d.HasError() {
+		t.Fatalf("Expected no error diagnostics, found %d errors", d.ErrorsCount())
+	}
+	if !unset.IdentityHeaderUserId.IsNull() {
+		t.Errorf("unset identity_header_user_id: expected null, got %#v", unset.IdentityHeaderUserId)
+	}
+}
+
+// The server rebuilds the provider row from the request on update, carrying over
+// only the API key and session keys. metadata_disabled and extra_values must
+// therefore be sent whenever known, or an update silently wipes them.
+func Test_agentNetworkProviderTerraformToRequest_sendsMetadataAndExtraValues(t *testing.T) {
+	data := AgentNetworkProviderModel{
+		ProviderId:       types.StringValue("openai_api"),
+		Name:             types.StringValue("OpenAI"),
+		UpstreamUrl:      types.StringValue("https://api.openai.com"),
+		MetadataDisabled: types.BoolValue(true),
+		ExtraValues: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"x-portkey-config": types.StringValue("pc-abc123"),
+		}),
+	}
+
+	req, d := agentNetworkProviderTerraformToRequest(context.Background(), &data)
+	if d.HasError() {
+		t.Fatalf("Expected no error diagnostics, found %d errors", d.ErrorsCount())
+	}
+
+	if req.MetadataDisabled == nil || !*req.MetadataDisabled {
+		t.Errorf("expected metadata_disabled to be sent as true, got %v", req.MetadataDisabled)
+	}
+	if req.ExtraValues == nil {
+		t.Fatal("expected extra_values to be sent, got nil (would wipe stored values)")
+	}
+	if got := (*req.ExtraValues)["x-portkey-config"]; got != "pc-abc123" {
+		t.Errorf("expected extra_values passthrough, got %q", got)
+	}
+
+	// Unknown values must be omitted so a create does not send placeholders.
+	unknown := AgentNetworkProviderModel{
+		ProviderId:       types.StringValue("custom"),
+		Name:             types.StringValue("n"),
+		UpstreamUrl:      types.StringValue("u"),
+		MetadataDisabled: types.BoolUnknown(),
+		ExtraValues:      types.MapUnknown(types.StringType),
+	}
+	req, d = agentNetworkProviderTerraformToRequest(context.Background(), &unknown)
+	if d.HasError() {
+		t.Fatalf("Expected no error diagnostics, found %d errors", d.ErrorsCount())
+	}
+	if req.MetadataDisabled != nil {
+		t.Errorf("expected unknown metadata_disabled to be omitted, got %v", *req.MetadataDisabled)
+	}
+	if req.ExtraValues != nil {
+		t.Errorf("expected unknown extra_values to be omitted, got %v", *req.ExtraValues)
+	}
+}

--- a/internal/provider/agent_network_settings_resource.go
+++ b/internal/provider/agent_network_settings_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -64,27 +66,28 @@ func (r *AgentNetworkSettings) Schema(_ context.Context, _ resource.SchemaReques
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"enable_log_collection": schema.BoolAttribute{
-				MarkdownDescription: "Collect per-request access-log entries for this account",
+				MarkdownDescription: "Collect per-request access-log entries for this account. Omit to leave the account's current value unchanged.",
 				Optional:            true,
 				Computed:            true,
-				Default:             booldefault.StaticBool(false),
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"enable_prompt_collection": schema.BoolAttribute{
-				MarkdownDescription: "Master switch for request/response prompt capture (effective only when a policy guardrail also enables it)",
+				MarkdownDescription: "Master switch for request/response prompt capture (effective only when a policy guardrail also enables it). Omit to leave the account's current value unchanged.",
 				Optional:            true,
 				Computed:            true,
-				Default:             booldefault.StaticBool(false),
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"redact_pii": schema.BoolAttribute{
-				MarkdownDescription: "Redact PII from captured prompts",
+				MarkdownDescription: "Redact PII from captured prompts. Omit to leave the account's current value unchanged.",
 				Optional:            true,
 				Computed:            true,
-				Default:             booldefault.StaticBool(false),
+				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"access_log_retention_days": schema.Int64Attribute{
-				MarkdownDescription: "Days to retain full access-log rows (0 or less = keep indefinitely)",
+				MarkdownDescription: "Days to retain full access-log rows (0 or less = keep indefinitely). Omit to leave the account's current value unchanged.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 			},
 		},
 	}
@@ -117,36 +120,76 @@ func agentNetworkSettingsAPIToTerraform(s *api.AgentNetworkSettings, data *Agent
 	}
 }
 
-// Create reads the current settings and stores them (singleton — no actual create).
+// settingsUpdateRequest builds an UpdateSettings request that starts from the
+// current server-side values and overrides only the fields the plan explicitly
+// set. The server replaces every mutable field on PUT, so without this merge an
+// omitted attribute would reset the account's value (turning off log/prompt
+// collection, or dropping access-log retention) instead of leaving it alone.
+func settingsUpdateRequest(data *AgentNetworkSettingsModel, current *api.AgentNetworkSettings) api.AgentNetworkSettingsRequest {
+	req := api.AgentNetworkSettingsRequest{
+		EnableLogCollection:    current.EnableLogCollection,
+		EnablePromptCollection: current.EnablePromptCollection,
+		RedactPii:              current.RedactPii,
+	}
+	if current.AccessLogRetentionDays != nil {
+		v := *current.AccessLogRetentionDays
+		req.AccessLogRetentionDays = &v
+	}
+
+	if !data.EnableLogCollection.IsNull() && !data.EnableLogCollection.IsUnknown() {
+		req.EnableLogCollection = data.EnableLogCollection.ValueBool()
+	}
+	if !data.EnablePromptCollection.IsNull() && !data.EnablePromptCollection.IsUnknown() {
+		req.EnablePromptCollection = data.EnablePromptCollection.ValueBool()
+	}
+	if !data.RedactPii.IsNull() && !data.RedactPii.IsUnknown() {
+		req.RedactPii = data.RedactPii.ValueBool()
+	}
+	if !data.AccessLogRetentionDays.IsNull() && !data.AccessLogRetentionDays.IsUnknown() {
+		v := int(data.AccessLogRetentionDays.ValueInt64())
+		req.AccessLogRetentionDays = &v
+	}
+	return req
+}
+
+// applySettings reads the current server-managed singleton, merges the planned
+// overrides onto it, and PUTs the result.
+func (r *AgentNetworkSettings) applySettings(ctx context.Context, data *AgentNetworkSettingsModel, diags *diag.Diagnostics) {
+	current, err := r.client.GetSettings(ctx)
+	if err != nil {
+		if netbird.IsNotFound(err) {
+			diags.AddError(
+				"Agent Network not bootstrapped",
+				"The account has no Agent Network settings row yet. It is created when the first Agent Network provider is created with bootstrap_cluster set.",
+			)
+			return
+		}
+		diags.AddError("Error reading Agent Network Settings", err.Error())
+		return
+	}
+
+	s, err := r.client.UpdateSettings(ctx, settingsUpdateRequest(data, current))
+	if err != nil {
+		diags.AddError("Error applying Agent Network Settings", err.Error())
+		return
+	}
+
+	agentNetworkSettingsAPIToTerraform(s, data)
+}
+
+// Create adopts the server-managed settings singleton, overriding only the
+// fields the configuration sets (singleton — no actual create).
 func (r *AgentNetworkSettings) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data AgentNetworkSettingsModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	apiReq := api.AgentNetworkSettingsRequest{
-		EnableLogCollection:    data.EnableLogCollection.ValueBool(),
-		EnablePromptCollection: data.EnablePromptCollection.ValueBool(),
-		RedactPii:              data.RedactPii.ValueBool(),
-	}
-	if !data.AccessLogRetentionDays.IsNull() && !data.AccessLogRetentionDays.IsUnknown() {
-		v := int(data.AccessLogRetentionDays.ValueInt64())
-		apiReq.AccessLogRetentionDays = &v
-	}
-	s, err := r.client.UpdateSettings(ctx, apiReq)
-	if err != nil {
-		if netbird.IsNotFound(err) {
-			resp.Diagnostics.AddError(
-				"Agent Network not bootstrapped",
-				"Settings cannot be applied before the first Agent Network provider is created. Create a netbird_agent_network_provider resource first.",
-			)
-			return
-		}
-		resp.Diagnostics.AddError("Error applying Agent Network Settings", err.Error())
+
+	r.applySettings(ctx, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	agentNetworkSettingsAPIToTerraform(s, &data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -178,29 +221,10 @@ func (r *AgentNetworkSettings) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	apiReq := api.AgentNetworkSettingsRequest{
-		EnableLogCollection:    data.EnableLogCollection.ValueBool(),
-		EnablePromptCollection: data.EnablePromptCollection.ValueBool(),
-		RedactPii:              data.RedactPii.ValueBool(),
-	}
-	if !data.AccessLogRetentionDays.IsNull() && !data.AccessLogRetentionDays.IsUnknown() {
-		v := int(data.AccessLogRetentionDays.ValueInt64())
-		apiReq.AccessLogRetentionDays = &v
-	}
-	s, err := r.client.UpdateSettings(ctx, apiReq)
-	if err != nil {
-		if netbird.IsNotFound(err) {
-			resp.Diagnostics.AddError(
-				"Agent Network not bootstrapped",
-				"Settings cannot be applied before the first Agent Network provider is created. Create a netbird_agent_network_provider resource first.",
-			)
-			return
-		}
-		resp.Diagnostics.AddError("Error updating Agent Network Settings", err.Error())
+	r.applySettings(ctx, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	agentNetworkSettingsAPIToTerraform(s, &data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/agent_network_settings_test.go
+++ b/internal/provider/agent_network_settings_test.go
@@ -1,0 +1,137 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+func Test_agentNetworkSettingsAPIToTerraform(t *testing.T) {
+	cases := []struct {
+		resource *api.AgentNetworkSettings
+		expected AgentNetworkSettingsModel
+	}{
+		{
+			resource: &api.AgentNetworkSettings{
+				Cluster:                "c1",
+				Subdomain:              "sub",
+				Endpoint:               "sub.c1",
+				EnableLogCollection:    true,
+				EnablePromptCollection: true,
+				RedactPii:              true,
+				AccessLogRetentionDays: valPtr(90),
+			},
+			expected: AgentNetworkSettingsModel{
+				Cluster:                types.StringValue("c1"),
+				Subdomain:              types.StringValue("sub"),
+				Endpoint:               types.StringValue("sub.c1"),
+				EnableLogCollection:    types.BoolValue(true),
+				EnablePromptCollection: types.BoolValue(true),
+				RedactPii:              types.BoolValue(true),
+				AccessLogRetentionDays: types.Int64Value(90),
+			},
+		},
+		{
+			// Absent retention means "keep indefinitely" and maps to null.
+			resource: &api.AgentNetworkSettings{
+				Cluster:   "c1",
+				Subdomain: "sub",
+				Endpoint:  "sub.c1",
+			},
+			expected: AgentNetworkSettingsModel{
+				Cluster:                types.StringValue("c1"),
+				Subdomain:              types.StringValue("sub"),
+				Endpoint:               types.StringValue("sub.c1"),
+				EnableLogCollection:    types.BoolValue(false),
+				EnablePromptCollection: types.BoolValue(false),
+				RedactPii:              types.BoolValue(false),
+				AccessLogRetentionDays: types.Int64Null(),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		var out AgentNetworkSettingsModel
+		agentNetworkSettingsAPIToTerraform(c.resource, &out)
+
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Expected:\n%#v\nFound:\n%#v", c.expected, out)
+		}
+	}
+}
+
+// The settings row is a server-managed singleton and the API replaces every
+// mutable field on PUT. Fields the configuration does not set must therefore
+// adopt the account's current value; sending schema defaults instead would
+// silently disable log/prompt collection or drop access-log retention.
+func Test_settingsUpdateRequest(t *testing.T) {
+	current := &api.AgentNetworkSettings{
+		EnableLogCollection:    true,
+		EnablePromptCollection: true,
+		RedactPii:              true,
+		AccessLogRetentionDays: valPtr(90),
+	}
+
+	cases := []struct {
+		name     string
+		data     AgentNetworkSettingsModel
+		expected api.AgentNetworkSettingsRequest
+	}{
+		{
+			name: "unset fields adopt current values",
+			data: AgentNetworkSettingsModel{
+				EnableLogCollection:    types.BoolNull(),
+				EnablePromptCollection: types.BoolUnknown(),
+				RedactPii:              types.BoolNull(),
+				AccessLogRetentionDays: types.Int64Null(),
+			},
+			expected: api.AgentNetworkSettingsRequest{
+				EnableLogCollection:    true,
+				EnablePromptCollection: true,
+				RedactPii:              true,
+				AccessLogRetentionDays: valPtr(90),
+			},
+		},
+		{
+			name: "set fields override current values",
+			data: AgentNetworkSettingsModel{
+				EnableLogCollection:    types.BoolValue(false),
+				EnablePromptCollection: types.BoolValue(false),
+				RedactPii:              types.BoolValue(false),
+				AccessLogRetentionDays: types.Int64Value(30),
+			},
+			expected: api.AgentNetworkSettingsRequest{
+				EnableLogCollection:    false,
+				EnablePromptCollection: false,
+				RedactPii:              false,
+				AccessLogRetentionDays: valPtr(30),
+			},
+		},
+		{
+			name: "partial config only overrides what it sets",
+			data: AgentNetworkSettingsModel{
+				EnableLogCollection:    types.BoolNull(),
+				EnablePromptCollection: types.BoolNull(),
+				RedactPii:              types.BoolValue(false),
+				AccessLogRetentionDays: types.Int64Null(),
+			},
+			expected: api.AgentNetworkSettingsRequest{
+				EnableLogCollection:    true,
+				EnablePromptCollection: true,
+				RedactPii:              false,
+				AccessLogRetentionDays: valPtr(90),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := settingsUpdateRequest(&c.data, current)
+			if !reflect.DeepEqual(out, c.expected) {
+				t.Fatalf("Expected:\n%#v\nFound:\n%#v", c.expected, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Four related defects in the merged agent-network support (#167) where the provider silently discards state that exists on the server, plus the first unit tests for this code.

All four were confirmed against a live management server, not just by reading the source — see **Verified against a running server** below.

## 1. `GetSettings` misreads the unbootstrapped response

The server deliberately answers **HTTP 200 with a JSON `null` body** (not 404) when an account's agent-network settings row has not been bootstrapped. Decoding that produced a zero-valued struct with a `nil` error, so `Read`'s `IsNotFound` branch never fired.

Instead of removing the resource, `Read` wrote `cluster=""`, `subdomain=""`, `endpoint=""` and all-false toggles into state. Anything interpolating `netbird_agent_network_settings.x.endpoint` silently resolved to the empty string, and `terraform plan` reported "No changes" for a resource that does not exist.

`GetSettings` now detects the `null`/empty body and returns a `NotFound` `APIError`, so the existing `Read` branch works as intended.

## 2. Settings `Create`/`Update` clobber account-level configuration

The API replaces **every** mutable field on `PUT`, but the request was built purely from the plan — where omitted toggles resolved to their `booldefault(false)`.

Adding `netbird_agent_network_settings` to manage just one field therefore turned off log collection and prompt collection and dropped access-log retention account-wide, on the very first apply. The retention change did not even appear in the plan (it renders as `(known after apply)`).

Fixed by dropping the defaults, adding `UseStateForUnknown`, and merging the plan's overrides onto the current server values via a new `settingsUpdateRequest` helper. **Omitting an attribute now leaves the account's value untouched** rather than resetting it.

## 3. Every provider update wiped `extra_values` and reset `metadata_disabled`

The server rebuilds the provider row from the request on update, carrying over only the API key and session keys. Neither field was in the schema, so neither was ever sent — meaning **any** `terraform apply` that touched a provider deleted its dashboard-configured `extra_values` (breaking Portkey/Bifrost routing headers) and reset `metadata_disabled` to false. No drift showed on the next plan, because the attributes did not exist.

Both are now managed attributes, sent whenever their value is known.

They are also declared on the provider **data source**, which shares `AgentNetworkProviderModel`. `terraform-plugin-framework` matches model to schema by reflection, so a field present on the struct but absent from the schema fails at runtime (`Struct defines fields not found in object`) while still compiling cleanly. PR 6 adds the data-source test that catches this class of mismatch.

## 4. An empty identity header failed the apply

An empty `identity_header_user_id` / `identity_header_groups` means "disable stamping for this dimension", but the API omits empty values from responses. A configured `""` came back as `null`, tripping `Error: Provider produced inconsistent result after apply`. There was no way to clear a header. An explicitly-configured `""` is now preserved.

## Verified against a running server

Against the dockerized management server (`test/compose.yml`):

- `GET /api/agent-network/settings` on an unbootstrapped account returns literally `200` + `null` — confirming (1).
- A `PUT` omitting the two fields returns `extra_values: null, metadata_disabled: false` — confirming (3) is real data loss, not a theoretical one.
- Bootstrapping seeds `enable_log_collection: true, access_log_retention_days: 30`, so the blind `PUT` in (2) really did disable a live setting.

## Tests

New unit tests cover the null-settings decode, the settings merge semantics (unset adopts current, set overrides), the provider conversions including the two new fields, the empty-identity-header preservation, and the body-less request path.

`go build`, `go vet`, `gofmt`, and `go test ./...` pass. Docs regenerated.

## Note for reviewers

The settings schema change is **behavioural**: omitted toggles now show `(known after apply)` on first apply and preserve the account value, instead of defaulting to `false`. That is the point of the fix — there is no way to both keep the `false` defaults and avoid clobbering, since the plan cannot distinguish "unset" from "explicitly false" once a default is applied.

---

**Stacked PR 2 of 7**, based on #177. Review that one first; this PR's diff is isolated to its own changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/terraform-provider-netbird/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787835978&installation_model_id=427504&pr_number=178&repository=netbirdio%2Fterraform-provider-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fterraform-provider-netbird%2Fpull%2F178&signature=245768e168d6d3561938cded1b443b38cea378e531dfc2a25da8f55944d6a517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring extra provider values and disabling identity-metadata injection.
  * Provider data sources now expose metadata and extra values.
  * Agent Network settings updates preserve existing account values when options are omitted.

* **Bug Fixes**
  * Improved handling of empty settings responses and body-less requests.
  * Preserved explicitly configured empty identity headers and unset values correctly.

* **Documentation**
  * Updated provider, data source, and settings documentation for the new attributes and value-preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->