### PR TITLE
Catch agent-network policy constraint violations at plan time

### DIFF
--- a/docs/resources/agent_network_policy.md
+++ b/docs/resources/agent_network_policy.md
@@ -43,9 +43,9 @@ resource "netbird_agent_network_policy" "engineering" {
 
 ### Required
 
-- `destination_provider_ids` (List of String) Agent Network provider IDs the source groups can reach
+- `destination_provider_ids` (List of String) Agent Network provider IDs the source groups can reach. Must contain at least one non-empty provider ID.
 - `name` (String) Display name for the policy
-- `source_groups` (List of String) NetBird group IDs whose members may call the destination providers
+- `source_groups` (List of String) NetBird group IDs whose members may call the destination providers. Must contain at least one non-empty group ID.
 
 ### Optional
 

--- a/internal/provider/agent_network_guardrail_data_source.go
+++ b/internal/provider/agent_network_guardrail_data_source.go
@@ -96,6 +96,30 @@ func (d *AgentNetworkGuardrailDataSource) Read(ctx context.Context, req datasour
 		return
 	}
 
+	// A known id identifies the record uniquely, so fetch it directly instead of
+	// listing everything and scanning. A name filter given alongside must agree.
+	if !data.Id.IsNull() && !data.Id.IsUnknown() {
+		found, err := d.client.GetGuardrail(ctx, data.Id.ValueString())
+		if err != nil {
+			if netbird.IsNotFound(err) {
+				resp.Diagnostics.AddError("No Match", "No Agent Network Guardrail matched the given filters")
+				return
+			}
+			resp.Diagnostics.AddError("Error reading Agent Network Guardrail", err.Error())
+			return
+		}
+		if matchString(found.Name, data.Name) < 0 {
+			resp.Diagnostics.AddError("No Match", "No Agent Network Guardrail matched the given filters")
+			return
+		}
+		resp.Diagnostics.Append(agentNetworkGuardrailAPIToTerraform(ctx, found, &data)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
 	guardrails, err := d.client.ListGuardrails(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Error listing Agent Network Guardrails", err.Error())

--- a/internal/provider/agent_network_guardrail_resource.go
+++ b/internal/provider/agent_network_guardrail_resource.go
@@ -239,10 +239,6 @@ func (r *AgentNetworkGuardrail) Update(ctx context.Context, req resource.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
-		return
-	}
 	apiReq, d := agentNetworkGuardrailTerraformToRequest(ctx, &data)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
@@ -266,7 +262,9 @@ func (r *AgentNetworkGuardrail) Delete(ctx context.Context, req resource.DeleteR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if err := r.client.DeleteGuardrail(ctx, data.Id.ValueString()); err != nil {
+	// A guardrail already removed out-of-band is not an error: the desired end
+	// state (gone) is satisfied, so let the destroy succeed.
+	if err := r.client.DeleteGuardrail(ctx, data.Id.ValueString()); err != nil && !netbird.IsNotFound(err) {
 		resp.Diagnostics.AddError("Error deleting Agent Network Guardrail", err.Error())
 	}
 }

--- a/internal/provider/agent_network_policy_data_source.go
+++ b/internal/provider/agent_network_policy_data_source.go
@@ -116,6 +116,30 @@ func (d *AgentNetworkPolicyDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
+	// A known id identifies the record uniquely, so fetch it directly instead of
+	// listing everything and scanning. A name filter given alongside must agree.
+	if !data.Id.IsNull() && !data.Id.IsUnknown() {
+		found, err := d.client.GetPolicy(ctx, data.Id.ValueString())
+		if err != nil {
+			if netbird.IsNotFound(err) {
+				resp.Diagnostics.AddError("No Match", "No Agent Network Policy matched the given filters")
+				return
+			}
+			resp.Diagnostics.AddError("Error reading Agent Network Policy", err.Error())
+			return
+		}
+		if matchString(found.Name, data.Name) < 0 {
+			resp.Diagnostics.AddError("No Match", "No Agent Network Policy matched the given filters")
+			return
+		}
+		resp.Diagnostics.Append(agentNetworkPolicyAPIToTerraform(ctx, found, &data)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
 	policies, err := d.client.ListPolicies(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Error listing Agent Network Policies", err.Error())

--- a/internal/provider/agent_network_policy_resource.go
+++ b/internal/provider/agent_network_policy_resource.go
@@ -7,13 +7,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -25,6 +27,7 @@ import (
 
 var _ resource.Resource = &AgentNetworkPolicy{}
 var _ resource.ResourceWithImportState = &AgentNetworkPolicy{}
+var _ resource.ResourceWithValidateConfig = &AgentNetworkPolicy{}
 
 func NewAgentNetworkPolicy() resource.Resource {
 	return &AgentNetworkPolicy{}
@@ -108,20 +111,31 @@ func (r *AgentNetworkPolicy) Schema(_ context.Context, _ resource.SchemaRequest,
 				Default:             booldefault.StaticBool(true),
 			},
 			"source_groups": schema.ListAttribute{
-				MarkdownDescription: "NetBird group IDs whose members may call the destination providers",
+				MarkdownDescription: "NetBird group IDs whose members may call the destination providers. Must contain at least one non-empty group ID.",
 				Required:            true,
 				ElementType:         types.StringType,
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
 			},
 			"destination_provider_ids": schema.ListAttribute{
-				MarkdownDescription: "Agent Network provider IDs the source groups can reach",
+				MarkdownDescription: "Agent Network provider IDs the source groups can reach. Must contain at least one non-empty provider ID.",
 				Required:            true,
 				ElementType:         types.StringType,
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
 			},
 			"guardrail_ids": schema.ListAttribute{
 				MarkdownDescription: "Agent Network guardrail IDs attached to this policy",
 				Optional:            true,
 				Computed:            true,
 				ElementType:         types.StringType,
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
 			},
 			"token_limit": schema.SingleNestedAttribute{
 				MarkdownDescription: "Per-policy token cap",
@@ -151,7 +165,6 @@ func (r *AgentNetworkPolicy) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:            true,
 						Computed:            true,
 						Default:             int64default.StaticInt64(2592000),
-						Validators:          []validator.Int64{int64validator.AtLeast(60)},
 					},
 				},
 			},
@@ -170,18 +183,19 @@ func (r *AgentNetworkPolicy) Schema(_ context.Context, _ resource.SchemaRequest,
 						MarkdownDescription: "USD allowed per source group per window (0 = uncapped)",
 						Optional:            true,
 						Computed:            true,
+						Default:             float64default.StaticFloat64(0),
 					},
 					"user_cap_usd": schema.Float64Attribute{
 						MarkdownDescription: "USD allowed per user per window (0 = uncapped)",
 						Optional:            true,
 						Computed:            true,
+						Default:             float64default.StaticFloat64(0),
 					},
 					"window_seconds": schema.Int64Attribute{
 						MarkdownDescription: "Reset frequency in seconds (minimum 60 when enabled)",
 						Optional:            true,
 						Computed:            true,
 						Default:             int64default.StaticInt64(2592000),
-						Validators:          []validator.Int64{int64validator.AtLeast(60)},
 					},
 				},
 			},
@@ -200,6 +214,86 @@ func (r *AgentNetworkPolicy) Configure(_ context.Context, req resource.Configure
 		return
 	}
 	r.client = newAgentNetworkClient(client)
+}
+
+// zeroCap reports whether a cap resolves to zero. A null or unknown cap picks up
+// the schema's 0 default, so it counts as zero for validation purposes.
+func zeroCap[T int64 | float64](null, unknown bool, v T) bool {
+	return null || unknown || v == 0
+}
+
+// validateLimit mirrors the server's validatePolicyLimits for one limit block.
+// Every rule applies only when the limit is enabled, matching the API: a
+// disabled limit may hold any values.
+func validateLimit(limit types.Object, name string, capNames [2]string, diags *diag.Diagnostics) {
+	if limit.IsNull() || limit.IsUnknown() {
+		return
+	}
+	attrs := limit.Attributes()
+
+	enabled, _ := attrs["enabled"].(types.Bool)
+	if enabled.IsUnknown() || !enabled.ValueBool() {
+		return
+	}
+
+	if w, ok := attrs["window_seconds"].(types.Int64); ok && !w.IsNull() && !w.IsUnknown() && w.ValueInt64() < 60 {
+		diags.AddAttributeError(
+			path.Root(name).AtName("window_seconds"),
+			"Invalid "+name,
+			fmt.Sprintf("%s.window_seconds must be at least 60 (one minute) when the limit is enabled, got %d.", name, w.ValueInt64()),
+		)
+	}
+
+	// The server requires at least one positive cap and rejects negatives.
+	var groupZero, userZero bool
+	switch g := attrs[capNames[0]].(type) {
+	case types.Int64:
+		u, _ := attrs[capNames[1]].(types.Int64)
+		groupZero, userZero = zeroCap(g.IsNull(), g.IsUnknown(), g.ValueInt64()), zeroCap(u.IsNull(), u.IsUnknown(), u.ValueInt64())
+		checkNonNegativeInt64(g, name, capNames[0], diags)
+		checkNonNegativeInt64(u, name, capNames[1], diags)
+	case types.Float64:
+		u, _ := attrs[capNames[1]].(types.Float64)
+		groupZero, userZero = zeroCap(g.IsNull(), g.IsUnknown(), g.ValueFloat64()), zeroCap(u.IsNull(), u.IsUnknown(), u.ValueFloat64())
+		checkNonNegativeFloat64(g, name, capNames[0], diags)
+		checkNonNegativeFloat64(u, name, capNames[1], diags)
+	}
+
+	if groupZero && userZero {
+		diags.AddAttributeError(
+			path.Root(name),
+			"Invalid "+name,
+			fmt.Sprintf("%s requires %s or %s to be greater than 0 when the limit is enabled. Caps default to 0 (uncapped), so at least one must be set explicitly.",
+				name, capNames[0], capNames[1]),
+		)
+	}
+}
+
+func checkNonNegativeInt64(v types.Int64, block, attrName string, diags *diag.Diagnostics) {
+	if !v.IsNull() && !v.IsUnknown() && v.ValueInt64() < 0 {
+		diags.AddAttributeError(path.Root(block).AtName(attrName), "Invalid "+block,
+			fmt.Sprintf("%s.%s must not be negative.", block, attrName))
+	}
+}
+
+func checkNonNegativeFloat64(v types.Float64, block, attrName string, diags *diag.Diagnostics) {
+	if !v.IsNull() && !v.IsUnknown() && v.ValueFloat64() < 0 {
+		diags.AddAttributeError(path.Root(block).AtName(attrName), "Invalid "+block,
+			fmt.Sprintf("%s.%s must not be negative.", block, attrName))
+	}
+}
+
+// ValidateConfig surfaces the server's limit rules at plan time instead of
+// letting them fail mid-apply.
+func (r *AgentNetworkPolicy) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data AgentNetworkPolicyModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	validateLimit(data.TokenLimit, "token_limit", [2]string{"group_cap", "user_cap"}, &resp.Diagnostics)
+	validateLimit(data.BudgetLimit, "budget_limit", [2]string{"group_cap_usd", "user_cap_usd"}, &resp.Diagnostics)
 }
 
 func agentNetworkPolicyAPIToTerraform(ctx context.Context, p *api.AgentNetworkPolicy, data *AgentNetworkPolicyModel) diag.Diagnostics {
@@ -343,10 +437,6 @@ func (r *AgentNetworkPolicy) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
-		return
-	}
 	apiReq, d := agentNetworkPolicyTerraformToRequest(ctx, &data)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
@@ -370,7 +460,9 @@ func (r *AgentNetworkPolicy) Delete(ctx context.Context, req resource.DeleteRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if err := r.client.DeletePolicy(ctx, data.Id.ValueString()); err != nil {
+	// A policy already removed out-of-band is not an error: the desired end
+	// state (gone) is satisfied, so let the destroy succeed.
+	if err := r.client.DeletePolicy(ctx, data.Id.ValueString()); err != nil && !netbird.IsNotFound(err) {
 		resp.Diagnostics.AddError("Error deleting Agent Network Policy", err.Error())
 	}
 }

--- a/internal/provider/agent_network_policy_test.go
+++ b/internal/provider/agent_network_policy_test.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func tokenLimit(enabled attr.Value, groupCap, userCap, window attr.Value) types.Object {
+	return types.ObjectValueMust(AgentNetworkTokenLimitModel{}.TFType().AttrTypes, map[string]attr.Value{
+		"enabled":        enabled,
+		"group_cap":      groupCap,
+		"user_cap":       userCap,
+		"window_seconds": window,
+	})
+}
+
+func budgetLimit(enabled attr.Value, groupCap, userCap, window attr.Value) types.Object {
+	return types.ObjectValueMust(AgentNetworkBudgetLimitModel{}.TFType().AttrTypes, map[string]attr.Value{
+		"enabled":        enabled,
+		"group_cap_usd":  groupCap,
+		"user_cap_usd":   userCap,
+		"window_seconds": window,
+	})
+}
+
+// The server only enforces its limit rules when the limit is enabled, and
+// rejects an enabled limit whose caps are both zero. Both must be caught at plan
+// time rather than mid-apply, without over-restricting disabled limits.
+func Test_validateLimit_tokenLimit(t *testing.T) {
+	cases := []struct {
+		name      string
+		limit     types.Object
+		wantError bool
+	}{
+		{
+			name:      "disabled with zero caps is fine",
+			limit:     tokenLimit(types.BoolValue(false), types.Int64Value(0), types.Int64Value(0), types.Int64Value(2592000)),
+			wantError: false,
+		},
+		{
+			// Regression: the schema's 0 defaults made this a mid-apply 422.
+			name:      "enabled with both caps zero is rejected",
+			limit:     tokenLimit(types.BoolValue(true), types.Int64Value(0), types.Int64Value(0), types.Int64Value(2592000)),
+			wantError: true,
+		},
+		{
+			name:      "enabled with omitted caps is rejected (they default to 0)",
+			limit:     tokenLimit(types.BoolValue(true), types.Int64Null(), types.Int64Null(), types.Int64Value(2592000)),
+			wantError: true,
+		},
+		{
+			name:      "enabled with only group_cap set is fine",
+			limit:     tokenLimit(types.BoolValue(true), types.Int64Value(1000), types.Int64Value(0), types.Int64Value(2592000)),
+			wantError: false,
+		},
+		{
+			name:      "enabled with only user_cap set is fine",
+			limit:     tokenLimit(types.BoolValue(true), types.Int64Value(0), types.Int64Value(1000), types.Int64Value(2592000)),
+			wantError: false,
+		},
+		{
+			name:      "enabled below the 60s window floor is rejected",
+			limit:     tokenLimit(types.BoolValue(true), types.Int64Value(1000), types.Int64Value(0), types.Int64Value(30)),
+			wantError: true,
+		},
+		{
+			// The server only applies the floor when enabled, so neither should we.
+			name:      "disabled below the 60s window floor is fine",
+			limit:     tokenLimit(types.BoolValue(false), types.Int64Value(0), types.Int64Value(0), types.Int64Value(30)),
+			wantError: false,
+		},
+		{
+			name:      "enabled with a negative cap is rejected",
+			limit:     tokenLimit(types.BoolValue(true), types.Int64Value(-1), types.Int64Value(5), types.Int64Value(2592000)),
+			wantError: true,
+		},
+		{
+			name:      "null limit block is fine",
+			limit:     types.ObjectNull(AgentNetworkTokenLimitModel{}.TFType().AttrTypes),
+			wantError: false,
+		},
+		{
+			// Values interpolated from other resources cannot be validated yet;
+			// the server remains the backstop.
+			name:      "unknown enabled is skipped",
+			limit:     tokenLimit(types.BoolUnknown(), types.Int64Value(0), types.Int64Value(0), types.Int64Value(2592000)),
+			wantError: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var diags diag.Diagnostics
+			validateLimit(c.limit, "token_limit", [2]string{"group_cap", "user_cap"}, &diags)
+
+			if got := diags.HasError(); got != c.wantError {
+				t.Fatalf("Expected error=%v, got error=%v (%v)", c.wantError, got, diags.Errors())
+			}
+		})
+	}
+}
+
+func Test_validateLimit_budgetLimit(t *testing.T) {
+	cases := []struct {
+		name      string
+		limit     types.Object
+		wantError bool
+	}{
+		{
+			name:      "enabled with both USD caps zero is rejected",
+			limit:     budgetLimit(types.BoolValue(true), types.Float64Value(0), types.Float64Value(0), types.Int64Value(2592000)),
+			wantError: true,
+		},
+		{
+			name:      "enabled with a USD cap set is fine",
+			limit:     budgetLimit(types.BoolValue(true), types.Float64Value(500), types.Float64Value(0), types.Int64Value(2592000)),
+			wantError: false,
+		},
+		{
+			name:      "enabled with a negative USD cap is rejected",
+			limit:     budgetLimit(types.BoolValue(true), types.Float64Value(-1), types.Float64Value(50), types.Int64Value(2592000)),
+			wantError: true,
+		},
+		{
+			name:      "disabled is unconstrained",
+			limit:     budgetLimit(types.BoolValue(false), types.Float64Value(0), types.Float64Value(0), types.Int64Value(1)),
+			wantError: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var diags diag.Diagnostics
+			validateLimit(c.limit, "budget_limit", [2]string{"group_cap_usd", "user_cap_usd"}, &diags)
+
+			if got := diags.HasError(); got != c.wantError {
+				t.Fatalf("Expected error=%v, got error=%v (%v)", c.wantError, got, diags.Errors())
+			}
+		})
+	}
+}

--- a/internal/provider/agent_network_provider_data_source.go
+++ b/internal/provider/agent_network_provider_data_source.go
@@ -135,6 +135,30 @@ func (d *AgentNetworkProviderDataSource) Read(ctx context.Context, req datasourc
 		return
 	}
 
+	// A known id identifies the record uniquely, so fetch it directly instead of
+	// listing everything and scanning. A name filter given alongside must agree.
+	if !data.Id.IsNull() && !data.Id.IsUnknown() {
+		found, err := d.client.GetProvider(ctx, data.Id.ValueString())
+		if err != nil {
+			if netbird.IsNotFound(err) {
+				resp.Diagnostics.AddError("No Match", "No Agent Network Provider matched the given filters")
+				return
+			}
+			resp.Diagnostics.AddError("Error reading Agent Network Provider", err.Error())
+			return
+		}
+		if matchString(found.Name, data.Name) < 0 {
+			resp.Diagnostics.AddError("No Match", "No Agent Network Provider matched the given filters")
+			return
+		}
+		resp.Diagnostics.Append(agentNetworkProviderAPIToTerraform(ctx, found, &data)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
 	providers, err := d.client.ListProviders(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Error listing Agent Network Providers", err.Error())

--- a/internal/provider/agent_network_provider_resource.go
+++ b/internal/provider/agent_network_provider_resource.go
@@ -323,10 +323,6 @@ func (r *AgentNetworkProvider) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
-		return
-	}
 	apiReq, d := agentNetworkProviderTerraformToRequest(ctx, &data)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
Moves several server-side rules from "fails partway through `apply`" to "fails during `plan`", makes destroys resilient, and removes some dead code. All the validation added here mirrors what the API actually enforces — including *when* it enforces it.

## Policy limits: `{ enabled = true }` could never work

The API rejects an enabled `token_limit`/`budget_limit` whose caps are both zero. But the schema defaults `group_cap` and `user_cap` to `0`, so the obvious shorthand —

```hcl
token_limit = {
  enabled        = true
  window_seconds = 86400
}
```

— sent `group_cap: 0, user_cap: 0` and always failed at apply with `422 limits.token_limit requires group_cap or user_cap to be greater than zero when enabled`. That directly contradicts the attributes' own documented "0 = uncapped" semantics.

Adds `ValidateConfig` mirroring the server's `validatePolicyLimits`: at least one positive cap, no negative caps, and the 60-second window floor. **Every rule is gated on `enabled`, matching the API** — a disabled limit may hold any values.

Because of that gating, the unconditional `int64validator.AtLeast(60)` on `window_seconds` is **removed**: it rejected `{ enabled = false, window_seconds = 30 }`, which the server accepts. Net effect is stricter where the server is strict and looser where it isn't.

Null and unknown caps are treated as zero, since an omitted cap picks up the `0` default. Unknown `enabled` (interpolated from another resource) skips validation — that can't be decided at plan time, and the server remains the backstop.

## Required lists accepted empty values

`source_groups` and `destination_provider_ids` are `Required`, but Terraform only enforces *presence*, not non-emptiness. A config like `source_groups = [for g in var.groups : g.id]` that evaluated to `[]` planned cleanly and then 400'd mid-apply — after other agent-network resources had already been created, leaving a half-applied dependency chain.

Adds `SizeAtLeast(1)` plus `ValueStringsAre(LengthAtLeast(1))`, matching the convention already used by `posture_check`, `nameserver_group`, `route` and `network_resource`.

While checking the server rules I found it also rejects empty *entries* in `guardrail_ids`, so that list gets the element check too (no size constraint — it's genuinely optional).

## Policy and guardrail deletes now tolerate 404

`AgentNetworkProvider.Delete` already ignored `IsNotFound`, but the policy and guardrail versions treated any error as fatal. Deleting one in the dashboard and then running `terraform destroy` failed with a 404 and left the resource wedged in state until a manual `terraform state rm`. Both now match the provider resource.

## Data sources fetch by id instead of scanning

A known `id` now uses `GetProvider`/`GetPolicy`/`GetGuardrail` — which already existed on the client but were unused — rather than listing every record and linear-scanning. A `name` filter supplied alongside the `id` must still agree, so the selector semantics are unchanged.

## Also in here

- Drops the unreachable `Update -> Create` branch from all three resources. `id` is `Computed` + `UseStateForUnknown`, so it is always known during `Update`. It also relied on a fragile `UpdateResponse` -> `CreateResponse` pointer cast, so this removes a real hazard rather than just dead weight.
- Gives `budget_limit`'s caps the same explicit `0` default the `token_limit` caps already had, so the two blocks behave alike.

## Tests

14 table-driven cases over `validateLimit` covering: disabled blocks are unconstrained, enabled-with-zero-caps rejected, omitted caps rejected (they default to 0), one-cap-set accepted, the window floor applied only when enabled, negative caps rejected, and null/unknown handling. Plus policy conversion round-trip tests.

`go build`, `go vet`, `gofmt` and `go test ./...` pass. Docs regenerated.

---

**Stacked PR 3 of 7**, based on #178. Review #177 and #178 first; this PR's diff is isolated to its own changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/terraform-provider-netbird/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787836915&installation_model_id=427504&pr_number=179&repository=netbirdio%2Fterraform-provider-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fterraform-provider-netbird%2Fpull%2F179&signature=3b0108430e4d7ce916828c2bd779790e3c32e1e0698db322fe53bfc3ff327e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->