### PR TITLE
Make agent-network bootstrapping discoverable; allow provider_id updates

### DIFF
--- a/docs/resources/agent_network_provider.md
+++ b/docs/resources/agent_network_provider.md
@@ -13,11 +13,19 @@ Manage Agent Network providers (upstream AI API endpoints), see [NetBird Docs](h
 ## Example Usage
 
 ```terraform
+# The account's Agent Network settings row — which supplies the endpoint agents
+# call — is created only when a provider is created with `bootstrap_cluster` set.
+# Creating providers without it leaves the account unbootstrapped, so set it on
+# at least the first provider. It is ignored once the account is bootstrapped.
+data "netbird_reverse_proxy_clusters" "all" {}
+
 resource "netbird_agent_network_provider" "openai" {
   provider_id  = "openai_api"
   name         = "OpenAI Production"
   upstream_url = "https://api.openai.com"
   api_key      = var.openai_api_key
+
+  bootstrap_cluster = data.netbird_reverse_proxy_clusters.all.clusters[0].address
 
   models = [
     {
@@ -46,7 +54,7 @@ resource "netbird_agent_network_provider" "openai" {
 
 ### Optional
 
-- `bootstrap_cluster` (String) Proxy cluster used when creating the first provider. Ignored on subsequent creates and all updates.
+- `bootstrap_cluster` (String) Proxy cluster that fronts this account's Agent Network endpoint. Setting this on a provider create bootstraps the account's Agent Network settings row (cluster, subdomain and endpoint); **an account with no providers created with `bootstrap_cluster` set is never bootstrapped**, leaving agents with no endpoint to call and `netbird_agent_network_settings` unmanageable. Ignored once the account is bootstrapped, and on all updates. Use the `netbird_reverse_proxy_clusters` data source to find valid cluster addresses.
 - `enabled` (Boolean) Whether the provider is enabled
 - `extra_values` (Map of String) Catalog-specific extra header values (e.g. `x-portkey-config` for Portkey gateways). Omit to leave the stored values unchanged. Empty values are dropped by the API.
 - `identity_header_groups` (String) Wire header name the proxy stamps with the caller's NetBird groups as a comma-separated list

--- a/examples/resources/netbird_agent_network_provider/resource.tf
+++ b/examples/resources/netbird_agent_network_provider/resource.tf
@@ -1,8 +1,16 @@
+# The account's Agent Network settings row — which supplies the endpoint agents
+# call — is created only when a provider is created with `bootstrap_cluster` set.
+# Creating providers without it leaves the account unbootstrapped, so set it on
+# at least the first provider. It is ignored once the account is bootstrapped.
+data "netbird_reverse_proxy_clusters" "all" {}
+
 resource "netbird_agent_network_provider" "openai" {
   provider_id  = "openai_api"
   name         = "OpenAI Production"
   upstream_url = "https://api.openai.com"
   api_key      = var.openai_api_key
+
+  bootstrap_cluster = data.netbird_reverse_proxy_clusters.all.clusters[0].address
 
   models = [
     {

--- a/internal/provider/agent_network_provider_resource.go
+++ b/internal/provider/agent_network_provider_resource.go
@@ -76,10 +76,14 @@ func (r *AgentNetworkProvider) Schema(_ context.Context, _ resource.SchemaReques
 				Computed:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
+			// Updated in place: the API accepts a new catalog id on PUT (validated
+			// against the catalog) and preserves the provider's identity and
+			// session keys. Forcing a replace here would make the destroy hit the
+			// server's "provider is in use by N policies" guard whenever a policy
+			// still references the provider.
 			"provider_id": schema.StringAttribute{
 				MarkdownDescription: "Catalog identifier for the upstream AI provider (e.g. `openai_api`, `anthropic_api`, `custom`)",
 				Required:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name shown in the dashboard",
@@ -95,8 +99,12 @@ func (r *AgentNetworkProvider) Schema(_ context.Context, _ resource.SchemaReques
 				Sensitive:           true,
 			},
 			"bootstrap_cluster": schema.StringAttribute{
-				MarkdownDescription: "Proxy cluster used when creating the first provider. Ignored on subsequent creates and all updates.",
-				Optional:            true,
+				MarkdownDescription: "Proxy cluster that fronts this account's Agent Network endpoint. Setting this on a provider create " +
+					"bootstraps the account's Agent Network settings row (cluster, subdomain and endpoint); **an account with no " +
+					"providers created with `bootstrap_cluster` set is never bootstrapped**, leaving agents with no endpoint to call " +
+					"and `netbird_agent_network_settings` unmanageable. Ignored once the account is bootstrapped, and on all updates. " +
+					"Use the `netbird_reverse_proxy_clusters` data source to find valid cluster addresses.",
+				Optional: true,
 			},
 			"enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether the provider is enabled",
@@ -288,11 +296,38 @@ func (r *AgentNetworkProvider) Create(ctx context.Context, req resource.CreateRe
 		resp.Diagnostics.AddError("Error creating Agent Network Provider", err.Error())
 		return
 	}
+	r.warnIfAccountUnbootstrapped(ctx, &data, &resp.Diagnostics)
 	resp.Diagnostics.Append(agentNetworkProviderAPIToTerraform(ctx, p, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// warnIfAccountUnbootstrapped flags the silent dead end where providers exist but
+// the account has no agent-network settings row, so there is no endpoint for
+// agents to call. The server only bootstraps that row when a provider is created
+// with bootstrap_cluster set, and it reports failures at debug level only, so
+// without this the misconfiguration is invisible until the settings resource
+// errors out. Only checked when bootstrap_cluster was omitted, so accounts that
+// are already bootstrapped (where the field is ignored) stay quiet.
+func (r *AgentNetworkProvider) warnIfAccountUnbootstrapped(ctx context.Context, data *AgentNetworkProviderModel, diags *diag.Diagnostics) {
+	if !data.BootstrapCluster.IsNull() && !data.BootstrapCluster.IsUnknown() && data.BootstrapCluster.ValueString() != "" {
+		return
+	}
+	if _, err := r.client.GetSettings(ctx); err == nil || !netbird.IsNotFound(err) {
+		// Bootstrapped already, or the check itself failed — either way this is
+		// advisory only and must never fail the apply.
+		return
+	}
+	diags.AddWarning(
+		"Agent Network account not bootstrapped",
+		"This provider was created but the account has no Agent Network settings row, so there is no "+
+			"endpoint for agents to call and netbird_agent_network_settings cannot be managed. The row is "+
+			"created only when a provider is created with `bootstrap_cluster` set. Set `bootstrap_cluster` "+
+			"on an Agent Network provider to bootstrap the account; the `netbird_reverse_proxy_clusters` "+
+			"data source lists valid cluster addresses.",
+	)
 }
 
 func (r *AgentNetworkProvider) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/agent_network_settings_resource.go
+++ b/internal/provider/agent_network_settings_resource.go
@@ -160,7 +160,11 @@ func (r *AgentNetworkSettings) applySettings(ctx context.Context, data *AgentNet
 		if netbird.IsNotFound(err) {
 			diags.AddError(
 				"Agent Network not bootstrapped",
-				"The account has no Agent Network settings row yet. It is created when the first Agent Network provider is created with bootstrap_cluster set.",
+				"The account has no Agent Network settings row yet, so there is nothing to configure. "+
+					"The row is created when an Agent Network provider is created with `bootstrap_cluster` set — "+
+					"creating a provider without it does not bootstrap the account. Set `bootstrap_cluster` on a "+
+					"netbird_agent_network_provider resource and re-apply; the `netbird_reverse_proxy_clusters` "+
+					"data source lists valid cluster addresses.",
 			)
 			return
 		}


### PR DESCRIPTION
Two unrelated usability problems that both leave the user stuck with no path forward from their config.

## `provider_id` forced a replacement it did not need

`provider_id` carried `stringplanmodifier.RequiresReplace()`, so changing it planned a destroy-then-create. With the shipped example's provider/policy pair, Terraform destroys the provider *before* updating the dependent policy — and the server refuses:

```
422 provider is in use by 1 policy (Engineering → OpenAI); detach it before deleting
```

The apply dies partway through the graph, and the user cannot fix it from config alone; they have to manually detach the policy first.

**The replacement was never necessary.** `provider_id` is mutable server-side:

- `Provider.FromAPIRequest` assigns `p.ProviderID = req.ProviderId` on update
- `manager.UpdateProvider` has no immutability guard
- `validate(req, false)` only checks the value is a known catalog id
- the provider's identity, session keys and `CreatedAt` are all preserved, and `reconcile()` runs afterwards

So the plan modifier was manufacturing the failure. Removing it makes `provider_id` an in-place update, which the API already supports.

Confirmed against a running management server: `PUT` changing `openai_api` -> `anthropic_api` returned the **same resource id**, with only `provider_id` changed. (An acceptance test asserting exactly this arrives in PR 7.)

## An account could silently never be bootstrapped

The account's agent-network settings row — which supplies the `endpoint` agents call — is created **only** when a provider is created with `bootstrap_cluster` set. Miss it and:

- no cluster, subdomain or endpoint is ever assigned
- the synth path no-ops, so agents have nothing to talk to
- the server logs the bootstrap miss at **debug level only**, so nothing surfaces
- adding `netbird_agent_network_settings` then failed with *"Settings cannot be applied before the first Agent Network provider is created"* — actively misleading, since a provider already existed

The shipped example omitted `bootstrap_cluster` entirely, so following the docs led straight into this. Three changes make it visible:

1. **The example now sets it**, from `netbird_reverse_proxy_clusters` — which is the only way to discover a valid address, since there is no agent-network clusters endpoint (agent-network reuses proxy cluster addresses).
2. **The attribute description** states that an account with no provider created with `bootstrap_cluster` set is never bootstrapped, and points at the data source.
3. **Provider create emits a warning** when `bootstrap_cluster` was omitted *and* the account still has no settings row.

The warning is deliberately narrow: it is skipped entirely when the field is set, so already-bootstrapped accounts (where the field is ignored) stay quiet and 2nd+ providers do not produce false positives. It can never fail the apply — if the check itself errors, it stays silent. Cost is one `GET` per provider create.

## Also in here

The settings "not bootstrapped" diagnostic is reworded. It previously told users to create a provider first even when one existed, pointing away from the actual fix; it now explains that the row comes from `bootstrap_cluster` and names the data source to find a valid address.

## Deliberately not done

- **Making `bootstrap_cluster` `Required`** — wrong semantics *and* breaking. It is meaningless for the 2nd+ provider in an account.
- **Auto-selecting a cluster** — too magical; it would silently bind the account to arbitrary infrastructure.

`go build`, `go vet`, `gofmt` and `go test ./...` pass. Docs regenerated.

---

**Stacked PR 4 of 7**, based on #179. Review #177 -> #179 first; this PR's diff is isolated to its own changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/terraform-provider-netbird/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787837228&installation_model_id=427504&pr_number=180&repository=netbirdio%2Fterraform-provider-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fterraform-provider-netbird%2Fpull%2F180&signature=abc4f74b332ed15bfeb427b3c4e6b2f865d09354ac91c2c6694705931e6f5417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->