### PR TITLE
Stop omitted policy limits from re-planning forever

### DIFF
--- a/internal/provider/agent_network_policy_resource.go
+++ b/internal/provider/agent_network_policy_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -141,6 +142,7 @@ func (r *AgentNetworkPolicy) Schema(_ context.Context, _ resource.SchemaRequest,
 				MarkdownDescription: "Per-policy token cap",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers:       []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
 						MarkdownDescription: "Whether the token limit is enforced",
@@ -172,6 +174,7 @@ func (r *AgentNetworkPolicy) Schema(_ context.Context, _ resource.SchemaRequest,
 				MarkdownDescription: "Per-policy USD spend cap",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers:       []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
 						MarkdownDescription: "Whether the budget limit is enforced",


### PR DESCRIPTION
A three-line fix for a permanent diff. `terraform plan` never converges on a policy that omits `token_limit` or `budget_limit`.

## Symptom

Apply a policy that does not set `budget_limit`, then plan again with **no config change**:

```
  # netbird_agent_network_policy.example will be updated in-place
  ~ resource "netbird_agent_network_policy" "example" {
      ~ budget_limit = {
          ~ enabled        = false -> (known after apply)
          ~ group_cap_usd  = 0 -> (known after apply)
          ~ user_cap_usd   = 0 -> (known after apply)
          ~ window_seconds = 0 -> (known after apply)
        } -> (known after apply)
        id   = "ainpol_..."
        name = "example"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Every plan reports a change, every apply issues a pointless `PUT`, and the resource never reaches a steady state. Anything asserting an empty plan — CI drift checks, `terraform plan -detailed-exitcode` — fails permanently.

## Cause

`token_limit` and `budget_limit` are `Optional` + `Computed` `SingleNestedAttribute`s with **no plan modifier**. When omitted from config:

1. On create the object is unknown, so the conversion skips it and the server stores zeros.
2. `APIToTerraform` writes the concrete zero object into state.
3. On the next plan the config is still null, and an `Optional`+`Computed` attribute with no modifier goes **unknown** again — so the whole block plans as `(known after apply)` and the diff is non-empty forever.

## Fix

`objectplanmodifier.UseStateForUnknown()` on both blocks, so an omitted limit keeps the value already in state.

## How it was found

An acceptance test, which is the only thing that surfaces this class of bug. The conversion helpers round-trip correctly in isolation, so every unit test passes; the drift only appears when a real plan runs against applied state. `Test_AgentNetworkPolicy_Create` failed with *"After applying this test step, the non-refresh plan was not empty"* and printed the diff above.

That test arrives in PR 7 and fails without this change — verified by running it against a live management server both ways.

Note this affects `token_limit` too; it simply did not show up in that test because the config set it explicitly.

`go build`, `go vet`, `gofmt` and `go test ./...` pass.

---

**Stacked PR 5 of 7**, based on #180. Review #177 -> #180 first; this PR's diff is isolated to its own changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/terraform-provider-netbird/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787837376&installation_model_id=427504&pr_number=181&repository=netbirdio%2Fterraform-provider-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fterraform-provider-netbird%2Fpull%2F181&signature=930d1141ad03b7b79445b13480310802555acc45cd4fd9c6c190ab095e2696ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->