### PR TITLE
Add agent-network conversion and data-source tests

### DIFF
--- a/internal/provider/agent_network_guardrail_test.go
+++ b/internal/provider/agent_network_guardrail_test.go
@@ -1,0 +1,149 @@
+package provider
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+func guardrailChecks(allowEnabled bool, models []string, captureEnabled, redactPii bool) api.AgentNetworkGuardrailChecks {
+	var c api.AgentNetworkGuardrailChecks
+	c.ModelAllowlist.Enabled = allowEnabled
+	c.ModelAllowlist.Models = models
+	c.PromptCapture.Enabled = captureEnabled
+	c.PromptCapture.RedactPii = redactPii
+	return c
+}
+
+func Test_agentNetworkGuardrailAPIToTerraform(t *testing.T) {
+	cases := []struct {
+		name     string
+		resource *api.AgentNetworkGuardrail
+		expected AgentNetworkGuardrailModel
+	}{
+		{
+			name: "populated",
+			resource: &api.AgentNetworkGuardrail{
+				Id:          "g1",
+				Name:        "strict",
+				Description: "tight allowlist",
+				Checks:      guardrailChecks(true, []string{"gpt-4o-mini", "gpt-4o"}, true, true),
+			},
+			expected: AgentNetworkGuardrailModel{
+				Id:          types.StringValue("g1"),
+				Name:        types.StringValue("strict"),
+				Description: types.StringValue("tight allowlist"),
+				ModelAllowlist: types.ObjectValueMust(AgentNetworkModelAllowlistModel{}.TFType().AttrTypes, map[string]attr.Value{
+					"enabled": types.BoolValue(true),
+					"models": types.ListValueMust(types.StringType, []attr.Value{
+						types.StringValue("gpt-4o-mini"), types.StringValue("gpt-4o"),
+					}),
+				}),
+				PromptCapture: types.ObjectValueMust(AgentNetworkPromptCaptureModel{}.TFType().AttrTypes, map[string]attr.Value{
+					"enabled":    types.BoolValue(true),
+					"redact_pii": types.BoolValue(true),
+				}),
+			},
+		},
+		{
+			// The server currently normalizes nil to []string{}, but a nil slice
+			// would convert to a NULL list rather than an empty one. Pinning the
+			// empty-slice case documents the boundary that keeps `models = []`
+			// from tripping the plan/apply consistency check.
+			name: "empty models list stays empty, not null",
+			resource: &api.AgentNetworkGuardrail{
+				Id:     "g2",
+				Name:   "loose",
+				Checks: guardrailChecks(false, []string{}, false, false),
+			},
+			expected: AgentNetworkGuardrailModel{
+				Id:          types.StringValue("g2"),
+				Name:        types.StringValue("loose"),
+				Description: types.StringValue(""),
+				ModelAllowlist: types.ObjectValueMust(AgentNetworkModelAllowlistModel{}.TFType().AttrTypes, map[string]attr.Value{
+					"enabled": types.BoolValue(false),
+					"models":  types.ListValueMust(types.StringType, []attr.Value{}),
+				}),
+				PromptCapture: types.ObjectValueMust(AgentNetworkPromptCaptureModel{}.TFType().AttrTypes, map[string]attr.Value{
+					"enabled":    types.BoolValue(false),
+					"redact_pii": types.BoolValue(false),
+				}),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var out AgentNetworkGuardrailModel
+			outDiag := agentNetworkGuardrailAPIToTerraform(context.Background(), c.resource, &out)
+			if outDiag.HasError() {
+				t.Fatalf("Expected no error diagnostics, found %d errors", outDiag.ErrorsCount())
+			}
+
+			if !reflect.DeepEqual(out, c.expected) {
+				t.Fatalf("Expected:\n%#v\nFound:\n%#v", c.expected, out)
+			}
+		})
+	}
+}
+
+// A nil Models slice from the API yields a null list, which does not round-trip
+// as an empty list. If the server ever stops normalizing nil to []string{} this
+// test documents the resulting difference instead of it surfacing as a confusing
+// "inconsistent result after apply" for users.
+func Test_agentNetworkGuardrailAPIToTerraform_nilModelsIsNullList(t *testing.T) {
+	res := &api.AgentNetworkGuardrail{Id: "g3", Name: "n", Checks: guardrailChecks(false, nil, false, false)}
+
+	var out AgentNetworkGuardrailModel
+	if d := agentNetworkGuardrailAPIToTerraform(context.Background(), res, &out); d.HasError() {
+		t.Fatalf("Expected no error diagnostics, found %d errors", d.ErrorsCount())
+	}
+
+	models, ok := out.ModelAllowlist.Attributes()["models"].(types.List)
+	if !ok {
+		t.Fatal("models attribute is not a list")
+	}
+	if !models.IsNull() {
+		t.Errorf("expected a nil API slice to produce a null list, got %#v", models)
+	}
+}
+
+func Test_agentNetworkGuardrailTerraformToRequest(t *testing.T) {
+	data := AgentNetworkGuardrailModel{
+		Name:        types.StringValue("strict"),
+		Description: types.StringValue("desc"),
+		ModelAllowlist: types.ObjectValueMust(AgentNetworkModelAllowlistModel{}.TFType().AttrTypes, map[string]attr.Value{
+			"enabled": types.BoolValue(true),
+			"models":  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("gpt-4o")}),
+		}),
+		PromptCapture: types.ObjectValueMust(AgentNetworkPromptCaptureModel{}.TFType().AttrTypes, map[string]attr.Value{
+			"enabled":    types.BoolValue(true),
+			"redact_pii": types.BoolValue(false),
+		}),
+	}
+
+	req, d := agentNetworkGuardrailTerraformToRequest(context.Background(), &data)
+	if d.HasError() {
+		t.Fatalf("Expected no error diagnostics, found %d errors", d.ErrorsCount())
+	}
+
+	if req.Name != "strict" {
+		t.Errorf("Name mismatch: got %q", req.Name)
+	}
+	if req.Description == nil || *req.Description != "desc" {
+		t.Errorf("Description mismatch: got %v", req.Description)
+	}
+	if !req.Checks.ModelAllowlist.Enabled {
+		t.Error("expected model_allowlist.enabled true")
+	}
+	if got := req.Checks.ModelAllowlist.Models; len(got) != 1 || got[0] != "gpt-4o" {
+		t.Errorf("Models mismatch: got %v", got)
+	}
+	if !req.Checks.PromptCapture.Enabled || req.Checks.PromptCapture.RedactPii {
+		t.Errorf("PromptCapture mismatch: %+v", req.Checks.PromptCapture)
+	}
+}

--- a/internal/provider/agent_network_policy_test.go
+++ b/internal/provider/agent_network_policy_test.go
@@ -1,11 +1,14 @@
 package provider
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/netbirdio/netbird/shared/management/http/api"
 )
 
 func tokenLimit(enabled attr.Value, groupCap, userCap, window attr.Value) types.Object {
@@ -140,5 +143,81 @@ func Test_validateLimit_budgetLimit(t *testing.T) {
 				t.Fatalf("Expected error=%v, got error=%v (%v)", c.wantError, got, diags.Errors())
 			}
 		})
+	}
+}
+
+func Test_agentNetworkPolicyAPIToTerraform(t *testing.T) {
+	res := &api.AgentNetworkPolicy{
+		Id:                     "pol1",
+		Name:                   "engineering",
+		Description:            "eng access",
+		Enabled:                true,
+		SourceGroups:           []string{"g1"},
+		DestinationProviderIds: []string{"p1"},
+		GuardrailIds:           []string{"gr1"},
+		Limits: api.AgentNetworkPolicyLimits{
+			TokenLimit:  api.AgentNetworkPolicyTokenLimit{Enabled: true, GroupCap: 100, UserCap: 10, WindowSeconds: 2592000},
+			BudgetLimit: api.AgentNetworkPolicyBudgetLimit{Enabled: true, GroupCapUsd: 500, UserCapUsd: 50, WindowSeconds: 2592000},
+		},
+	}
+
+	expected := AgentNetworkPolicyModel{
+		Id:                     types.StringValue("pol1"),
+		Name:                   types.StringValue("engineering"),
+		Description:            types.StringValue("eng access"),
+		Enabled:                types.BoolValue(true),
+		SourceGroups:           types.ListValueMust(types.StringType, []attr.Value{types.StringValue("g1")}),
+		DestinationProviderIds: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("p1")}),
+		GuardrailIds:           types.ListValueMust(types.StringType, []attr.Value{types.StringValue("gr1")}),
+		TokenLimit:             tokenLimit(types.BoolValue(true), types.Int64Value(100), types.Int64Value(10), types.Int64Value(2592000)),
+		BudgetLimit:            budgetLimit(types.BoolValue(true), types.Float64Value(500), types.Float64Value(50), types.Int64Value(2592000)),
+	}
+
+	var out AgentNetworkPolicyModel
+	if d := agentNetworkPolicyAPIToTerraform(context.Background(), res, &out); d.HasError() {
+		t.Fatalf("Expected no error diagnostics, found %d errors", d.ErrorsCount())
+	}
+	if !reflect.DeepEqual(out, expected) {
+		t.Fatalf("Expected:\n%#v\nFound:\n%#v", expected, out)
+	}
+}
+
+func Test_agentNetworkPolicyTerraformToRequest(t *testing.T) {
+	data := AgentNetworkPolicyModel{
+		Name:                   types.StringValue("engineering"),
+		Description:            types.StringValue("eng access"),
+		Enabled:                types.BoolValue(true),
+		SourceGroups:           types.ListValueMust(types.StringType, []attr.Value{types.StringValue("g1")}),
+		DestinationProviderIds: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("p1")}),
+		GuardrailIds:           types.ListValueMust(types.StringType, []attr.Value{types.StringValue("gr1")}),
+		TokenLimit:             tokenLimit(types.BoolValue(true), types.Int64Value(100), types.Int64Value(10), types.Int64Value(2592000)),
+		BudgetLimit:            budgetLimit(types.BoolValue(true), types.Float64Value(500), types.Float64Value(50), types.Int64Value(2592000)),
+	}
+
+	req, d := agentNetworkPolicyTerraformToRequest(context.Background(), &data)
+	if d.HasError() {
+		t.Fatalf("Expected no error diagnostics, found %d errors", d.ErrorsCount())
+	}
+
+	if req.Name != "engineering" {
+		t.Errorf("Name mismatch: got %q", req.Name)
+	}
+	if len(req.SourceGroups) != 1 || req.SourceGroups[0] != "g1" {
+		t.Errorf("SourceGroups mismatch: got %v", req.SourceGroups)
+	}
+	if len(req.DestinationProviderIds) != 1 || req.DestinationProviderIds[0] != "p1" {
+		t.Errorf("DestinationProviderIds mismatch: got %v", req.DestinationProviderIds)
+	}
+	if req.GuardrailIds == nil || len(*req.GuardrailIds) != 1 {
+		t.Errorf("GuardrailIds mismatch: got %v", req.GuardrailIds)
+	}
+	if req.Limits == nil {
+		t.Fatal("expected limits to be sent")
+	}
+	if !req.Limits.TokenLimit.Enabled || req.Limits.TokenLimit.GroupCap != 100 {
+		t.Errorf("TokenLimit mismatch: %+v", req.Limits.TokenLimit)
+	}
+	if !req.Limits.BudgetLimit.Enabled || req.Limits.BudgetLimit.GroupCapUsd != 500 {
+		t.Errorf("BudgetLimit mismatch: %+v", req.Limits.BudgetLimit)
 	}
 }

--- a/internal/provider/agent_network_provider_data_source_test.go
+++ b/internal/provider/agent_network_provider_data_source_test.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
+)
+
+const twoProvidersJSON = `[
+  {"id":"p1","provider_id":"openai_api","name":"OpenAI","upstream_url":"https://api.openai.com","enabled":true,"skip_tls_verification":false,"metadata_disabled":false,"models":[]},
+  {"id":"p2","provider_id":"anthropic_api","name":"Anthropic","upstream_url":"https://api.anthropic.com","enabled":true,"skip_tls_verification":false,"metadata_disabled":false,"models":[]}
+]`
+
+const oneProviderJSON = `{"id":"p1","provider_id":"openai_api","name":"OpenAI","upstream_url":"https://api.openai.com","enabled":true,"skip_tls_verification":false,"metadata_disabled":false,"models":[]}`
+
+// readProviderDataSource drives the data source's Read end to end against a stub
+// API. This is the only unit-level way to exercise the selector logic together
+// with the schema/model round-trip: a model field missing from the schema fails
+// here as a conversion error even though it compiles fine.
+func readProviderDataSource(t *testing.T, serverURL, id, name string) diag.Diagnostics {
+	t.Helper()
+	ctx := context.Background()
+
+	d := &AgentNetworkProviderDataSource{client: newAgentNetworkClient(netbird.New(serverURL, "test-token"))}
+
+	schemaResp := datasource.SchemaResponse{}
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema error: %v", schemaResp.Diagnostics.Errors())
+	}
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatal("schema type is not an object")
+	}
+
+	vals := map[string]tftypes.Value{}
+	for attrName, attrType := range objType.AttributeTypes {
+		var v any
+		switch attrName {
+		case "id":
+			v = nullableString(id)
+		case "name":
+			v = nullableString(name)
+		}
+		vals[attrName] = tftypes.NewValue(attrType, v)
+	}
+
+	resp := datasource.ReadResponse{
+		State: tfsdk.State{Raw: tftypes.NewValue(objType, nil), Schema: schemaResp.Schema},
+	}
+	d.Read(ctx, datasource.ReadRequest{
+		Config: tfsdk.Config{Raw: tftypes.NewValue(objType, vals), Schema: schemaResp.Schema},
+	}, &resp)
+
+	return resp.Diagnostics
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func Test_AgentNetworkProviderDataSource_Read(t *testing.T) {
+	cases := []struct {
+		name       string
+		id         string
+		filterName string
+		wantErr    string // empty means success expected
+		wantNoList bool   // by-id lookups must not hit the list endpoint
+	}{
+		{name: "by name selects the matching provider", filterName: "Anthropic"},
+		{name: "by id uses the direct GET", id: "p1", wantNoList: true},
+		{name: "by id and matching name", id: "p1", filterName: "OpenAI", wantNoList: true},
+		// Regression: an inverted match filter previously let every
+		// non-matching row count as a match.
+		{name: "unknown name reports no match", filterName: "Nope", wantErr: "No Match"},
+		{name: "id and mismatched name reports no match", id: "p1", filterName: "Anthropic", wantErr: "No Match"},
+		{name: "no selector is rejected", wantErr: "No selector"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var listed bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				if strings.HasPrefix(r.URL.Path, "/api/agent-network/providers/") {
+					_, _ = w.Write([]byte(oneProviderJSON))
+					return
+				}
+				listed = true
+				_, _ = w.Write([]byte(twoProvidersJSON))
+			}))
+			defer server.Close()
+
+			diags := readProviderDataSource(t, server.URL, c.id, c.filterName)
+
+			if c.wantErr != "" {
+				if !diags.HasError() {
+					t.Fatalf("Expected error %q, got none", c.wantErr)
+				}
+				var found bool
+				for _, e := range diags.Errors() {
+					if strings.Contains(e.Summary(), c.wantErr) {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("Expected an error mentioning %q, got: %v", c.wantErr, diags.Errors())
+				}
+				return
+			}
+
+			if diags.HasError() {
+				t.Fatalf("Expected no error, got: %v", diags.Errors())
+			}
+			if c.wantNoList && listed {
+				t.Error("a known id should be fetched directly, not by listing every provider")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds unit test coverage for the agent-network resources and data sources. Tests only — no production code.

Follows the existing shape used elsewhere in the package: `Test_<x>APIToTerraform` tables compared with `reflect.DeepEqual`.

## Why the data-source test drives `Read`

Rather than calling the conversion helpers directly, the data-source test exercises the full `Read` path — schema, selector logic and the model round-trip together.

That combination is the only unit-level way to catch a **schema/model mismatch**. `terraform-plugin-framework` matches the model struct to the schema by reflection, so a field present on the struct but missing from the schema fails at *runtime* (`Struct defines fields not found in object`) while `go build` stays perfectly clean. Since the provider resource and data source share `AgentNetworkProviderModel`, that is a live risk whenever the model changes, and a test that only covers the conversion functions would not notice.

## Data-source cases

- selection by `name`
- the by-id fast path, asserting it does not fall back to listing every provider
- `id` plus a matching `name`
- `id` plus a mismatched `name` -> `No Match`
- an unknown `name` -> `No Match`
- no selector -> `No selector`

## Guardrail cases

Conversions both directions, plus a pinned boundary worth being explicit about: `types.ListValueFrom` on a **nil** `[]string` produces a **null** list, not an empty one. The server currently normalizes a nil `Models` slice to `[]`, so this is latent — but if that ever changes, the difference reaches users as `Provider produced inconsistent result after apply: .model_allowlist.models: was cty.ListValEmpty(cty.String), but now null`. Both the empty-slice and nil-slice cases are asserted so the behaviour is documented rather than discovered later.

## Policy cases

`APIToTerraform` and `TerraformToRequest` round-trips including both limit blocks and the guardrail id list.

Total across the agent-network unit tests after this PR: **43 passing cases**. `go build`, `go vet`, `gofmt` and `go test ./...` pass.

---

**Stacked PR 6 of 7**, based on #181. Review #177 -> #181 first; this PR's diff is isolated to its own changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/terraform-provider-netbird/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787837610&installation_model_id=427504&pr_number=182&repository=netbirdio%2Fterraform-provider-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fterraform-provider-netbird%2Fpull%2F182&signature=2ec625100797bc5d7c4cc920d73f56dd10dae611a51427f7c10aaf8234e3d727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->