### PR TITLE
Add agent-network acceptance tests

### DIFF
--- a/internal/provider/agent_network_acc_test.go
+++ b/internal/provider/agent_network_acc_test.go
@@ -1,0 +1,396 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+// The acceptance tests below run against the dockerized management server
+// started by testEnsureManagementRunning. Agent Network needs a proxy cluster
+// address to bootstrap the account's settings row, but the server stores that
+// string verbatim without validating it, so a placeholder is enough.
+const testBootstrapCluster = "acc.test.invalid"
+
+func testAgentNetworkClient() *agentNetworkClient {
+	return newAgentNetworkClient(testClient())
+}
+
+func testGetProvider(id string) (*api.AgentNetworkProvider, error) {
+	return testAgentNetworkClient().GetProvider(context.Background(), id)
+}
+
+func testAgentNetworkProviderResource(rName, name, extraValues, metadataDisabled string) string {
+	return fmt.Sprintf(`resource "netbird_agent_network_provider" "%s" {
+	provider_id       = "openai_api"
+	name              = "%s"
+	upstream_url      = "https://api.openai.com"
+	api_key           = "sk-acc-test"
+	bootstrap_cluster = "%s"
+	extra_values      = %s
+	metadata_disabled = %s
+}`, rName, name, testBootstrapCluster, extraValues, metadataDisabled)
+}
+
+func Test_AgentNetworkProvider_Create(t *testing.T) {
+	rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_agent_network_provider." + rName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       testAgentNetworkProviderResource(rName, rName, `{ "x-portkey-config" = "pc-acc" }`, "true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "provider_id", "openai_api"),
+					resource.TestCheckResourceAttr(rNameFull, "metadata_disabled", "true"),
+					resource.TestCheckResourceAttr(rNameFull, "extra_values.x-portkey-config", "pc-acc"),
+					func(s *terraform.State) error {
+						p, err := testGetProvider(s.RootModule().Resources[rNameFull].Primary.Attributes["id"])
+						if err != nil {
+							return err
+						}
+						if !p.MetadataDisabled {
+							return fmt.Errorf("metadata_disabled not persisted on the management server")
+						}
+						if p.ExtraValues == nil || (*p.ExtraValues)["x-portkey-config"] != "pc-acc" {
+							return fmt.Errorf("extra_values not persisted, found %v", p.ExtraValues)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// The API rebuilds the provider row from the request on update, so any field the
+// provider omits is dropped. Changing only the name must not wipe extra_values
+// or reset metadata_disabled.
+func Test_AgentNetworkProvider_UpdatePreservesExtraValues(t *testing.T) {
+	rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_agent_network_provider." + rName
+
+	checkPersisted := func(s *terraform.State) error {
+		p, err := testGetProvider(s.RootModule().Resources[rNameFull].Primary.Attributes["id"])
+		if err != nil {
+			return err
+		}
+		if p.ExtraValues == nil || (*p.ExtraValues)["x-portkey-config"] != "pc-acc" {
+			return fmt.Errorf("extra_values lost on update, found %v", p.ExtraValues)
+		}
+		if !p.MetadataDisabled {
+			return fmt.Errorf("metadata_disabled reset on update")
+		}
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       testAgentNetworkProviderResource(rName, rName, `{ "x-portkey-config" = "pc-acc" }`, "true"),
+				Check:        resource.ComposeAggregateTestCheckFunc(checkPersisted),
+			},
+			{
+				// Only the name changes; the other two are left in state.
+				ResourceName: rName,
+				Config:       testAgentNetworkProviderResource(rName, rName+"-renamed", `{ "x-portkey-config" = "pc-acc" }`, "true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "name", rName+"-renamed"),
+					checkPersisted,
+				),
+			},
+		},
+	})
+}
+
+// provider_id is mutable server-side, so changing it must update in place. A
+// forced replacement would have to delete the provider first, which the server
+// refuses while a policy still references it.
+func Test_AgentNetworkProvider_ProviderIdUpdatesInPlace(t *testing.T) {
+	rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_agent_network_provider." + rName
+
+	config := func(providerID, upstream string) string {
+		return fmt.Sprintf(`resource "netbird_agent_network_provider" "%s" {
+	provider_id       = "%s"
+	name              = "%s"
+	upstream_url      = "%s"
+	api_key           = "sk-acc-test"
+	bootstrap_cluster = "%s"
+}`, rName, providerID, rName, upstream, testBootstrapCluster)
+	}
+
+	var firstID string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       config("openai_api", "https://api.openai.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(func(s *terraform.State) error {
+					firstID = s.RootModule().Resources[rNameFull].Primary.Attributes["id"]
+					return nil
+				}),
+			},
+			{
+				ResourceName: rName,
+				Config:       config("anthropic_api", "https://api.anthropic.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "provider_id", "anthropic_api"),
+					func(s *terraform.State) error {
+						if got := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]; got != firstID {
+							return fmt.Errorf("provider was replaced (id %s -> %s); provider_id should update in place", firstID, got)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func Test_AgentNetworkGuardrail_Create(t *testing.T) {
+	rName := "ang" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_agent_network_guardrail." + rName
+
+	config := func(models string, redactPii string) string {
+		return fmt.Sprintf(`resource "netbird_agent_network_guardrail" "%s" {
+	name        = "%s"
+	description = "acceptance test"
+	model_allowlist = {
+		enabled = true
+		models  = %s
+	}
+	prompt_capture = {
+		enabled    = true
+		redact_pii = %s
+	}
+}`, rName, rName, models, redactPii)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       config(`["gpt-4.1"]`, "true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "model_allowlist.models.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "prompt_capture.redact_pii", "true"),
+				),
+			},
+			{
+				ResourceName: rName,
+				Config:       config(`["gpt-4.1", "o4-mini"]`, "false"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "model_allowlist.models.#", "2"),
+					resource.TestCheckResourceAttr(rNameFull, "prompt_capture.redact_pii", "false"),
+				),
+			},
+		},
+	})
+}
+
+func Test_AgentNetworkPolicy_Create(t *testing.T) {
+	rName := "anpol" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_agent_network_policy." + rName
+
+	config := fmt.Sprintf(`
+resource "netbird_group" "%[1]s" {
+	name = "%[1]s-group"
+}
+
+resource "netbird_agent_network_provider" "%[1]s" {
+	provider_id       = "openai_api"
+	name              = "%[1]s-provider"
+	upstream_url      = "https://api.openai.com"
+	api_key           = "sk-acc-test"
+	bootstrap_cluster = "%[2]s"
+}
+
+resource "netbird_agent_network_guardrail" "%[1]s" {
+	name = "%[1]s-guardrail"
+	model_allowlist = {
+		enabled = true
+		models  = ["gpt-4.1"]
+	}
+	prompt_capture = {
+		enabled = false
+	}
+}
+
+resource "netbird_agent_network_policy" "%[1]s" {
+	name                     = "%[1]s"
+	source_groups            = [netbird_group.%[1]s.id]
+	destination_provider_ids = [netbird_agent_network_provider.%[1]s.id]
+	guardrail_ids            = [netbird_agent_network_guardrail.%[1]s.id]
+
+	token_limit = {
+		enabled        = true
+		group_cap      = 1000000
+		window_seconds = 86400
+	}
+}`, rName, testBootstrapCluster)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(rNameFull, "id"),
+					resource.TestCheckResourceAttr(rNameFull, "source_groups.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "destination_provider_ids.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "guardrail_ids.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "token_limit.enabled", "true"),
+					resource.TestCheckResourceAttr(rNameFull, "token_limit.group_cap", "1000000"),
+					// Not set in config, so it takes the schema default.
+					resource.TestCheckResourceAttr(rNameFull, "token_limit.user_cap", "0"),
+				),
+			},
+		},
+	})
+}
+
+// The server rejects an enabled limit whose caps are all zero. That must be
+// caught during plan rather than failing partway through an apply.
+func Test_AgentNetworkPolicy_EnabledLimitNeedsACap(t *testing.T) {
+	rName := "anpol" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	config := fmt.Sprintf(`
+resource "netbird_group" "%[1]s" {
+	name = "%[1]s-group"
+}
+
+resource "netbird_agent_network_policy" "%[1]s" {
+	name                     = "%[1]s"
+	source_groups            = [netbird_group.%[1]s.id]
+	destination_provider_ids = ["does-not-matter"]
+
+	token_limit = {
+		enabled = true
+	}
+}`, rName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       config,
+				ExpectError:  regexp.MustCompile(`group_cap or user_cap to be greater than 0`),
+			},
+		},
+	})
+}
+
+// Required lists must be rejected at plan time when empty.
+func Test_AgentNetworkPolicy_EmptySourceGroupsRejected(t *testing.T) {
+	rName := "anpol" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	config := fmt.Sprintf(`resource "netbird_agent_network_policy" "%[1]s" {
+	name                     = "%[1]s"
+	source_groups            = []
+	destination_provider_ids = ["does-not-matter"]
+}`, rName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       config,
+				ExpectError:  regexp.MustCompile(`at least 1 element`),
+			},
+		},
+	})
+}
+
+// The settings row is a server-managed singleton and the API replaces every
+// mutable field on PUT. Managing only one field must leave the others at their
+// existing account values instead of resetting them to the schema defaults.
+func Test_AgentNetworkSettings_AdoptsExistingValues(t *testing.T) {
+	rName := "ans" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_agent_network_settings." + rName
+
+	// The provider create bootstraps the settings row, which the server seeds
+	// with log collection enabled. The settings resource manages only the
+	// retention, so log collection must survive.
+	config := fmt.Sprintf(`
+resource "netbird_agent_network_provider" "%[1]s" {
+	provider_id       = "openai_api"
+	name              = "%[1]s-provider"
+	upstream_url      = "https://api.openai.com"
+	api_key           = "sk-acc-test"
+	bootstrap_cluster = "%[2]s"
+}
+
+resource "netbird_agent_network_settings" "%[1]s" {
+	access_log_retention_days = 45
+	depends_on                = [netbird_agent_network_provider.%[1]s]
+}`, rName, testBootstrapCluster)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testEnsureManagementRunning(t)
+			// Normalize the singleton so the assertion does not depend on
+			// whatever a previous run left behind.
+			c := testAgentNetworkClient()
+			if cur, err := c.GetSettings(context.Background()); err == nil && !cur.EnableLogCollection {
+				retention := 30
+				if _, err := c.UpdateSettings(context.Background(), api.AgentNetworkSettingsRequest{
+					EnableLogCollection:    true,
+					AccessLogRetentionDays: &retention,
+				}); err != nil {
+					t.Fatalf("failed to normalize agent-network settings: %v", err)
+				}
+			}
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "access_log_retention_days", "45"),
+					resource.TestCheckResourceAttrSet(rNameFull, "endpoint"),
+					// Unmanaged in config, so it must reflect the account value.
+					resource.TestCheckResourceAttr(rNameFull, "enable_log_collection", "true"),
+					func(s *terraform.State) error {
+						got, err := testAgentNetworkClient().GetSettings(context.Background())
+						if err != nil {
+							return err
+						}
+						if !got.EnableLogCollection {
+							return fmt.Errorf("enable_log_collection was clobbered to false by an unrelated settings apply")
+						}
+						if got.AccessLogRetentionDays == nil || *got.AccessLogRetentionDays != 45 {
+							return fmt.Errorf("access_log_retention_days not applied, found %v", got.AccessLogRetentionDays)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds acceptance test coverage for the four agent-network resources, exercising them against the dockerized management server. Tests only — no production code.

Uses the existing harness (`testEnsureManagementRunning` + `testAccProtoV6ProviderFactories`), so these skip unless `TF_ACC` is set and need no changes to `test/compose.yml`.

## Why acceptance tests here

Some failure modes only appear when a real plan and apply run against live state. The conversion helpers can round-trip perfectly in isolation while the resource still never reaches a steady state, or while an update quietly drops a field the server was holding. These eight tests target that class.

## Coverage

**Provider**
- create, with `extra_values` and `metadata_disabled` verified directly against the API
- **update preserves `extra_values` and `metadata_disabled`** — changes only `name`, then asserts both survived on the server. The API rebuilds the provider row from the request and drops anything omitted, so a bare `PUT` really does come back with `extra_values: null, metadata_disabled: false`; this pins that the provider sends them.
- **`provider_id` updates in place** — asserts the resource `id` is unchanged across the change rather than a new one appearing, i.e. no replacement was planned.

**Guardrail** — create and update, covering the model allowlist and prompt capture blocks.

**Policy** — create with a group, provider, guardrail and token limit, asserting the list attributes and that an unset cap takes its schema default. This is also the test that exercises plan convergence, since the framework fails a step whose post-apply plan is non-empty.

**Plan-time validation** — `ExpectError` for an enabled limit with no cap, and for an empty `source_groups`. Both would otherwise be rejected partway through an apply.

**Settings** — **adopts the account's existing values.** The provider create bootstraps the settings row with log collection enabled; a settings resource managing only the retention must leave that alone. `PreCheck` normalizes the singleton first so the assertion does not depend on what a previous run left behind, and the check reads back from the API rather than trusting state.

## Notes

Agent Network needs a proxy cluster address to bootstrap an account, but the server stores it verbatim without validating it, so a placeholder (`acc.test.invalid`) is enough — the tests need no real proxy infrastructure. The agent-network endpoints are registered unconditionally, so `netbirdio/management:latest` serves them as-is.

All eight pass against a live management server. The unit suite is unaffected: `go build`, `go vet`, `gofmt` and `go test ./...` pass without `TF_ACC`.

---

**Stacked PR 7 of 7**, based on #182. Review #177 -> #182 first; this PR's diff is isolated to its own changes.

Note on merge order: `Test_AgentNetworkPolicy_Create` asserts an empty post-apply plan, so it depends on #181. Merging this ahead of #181 would leave that test failing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/terraform-provider-netbird/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787837766&installation_model_id=427504&pr_number=183&repository=netbirdio%2Fterraform-provider-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fterraform-provider-netbird%2Fpull%2F183&signature=3080035695a9f3cc0477d5c1d1306489f950c088418c5f7a5ce32ef0ff75848d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->