### PR TITLE
Mark reverse proxy custom_headers as sensitive

### DIFF
--- a/docs/data-sources/reverse_proxy_service.md
+++ b/docs/data-sources/reverse_proxy_service.md
@@ -138,7 +138,7 @@ Read-Only:
 
 Read-Only:
 
-- `custom_headers` (Map of String) Extra headers sent to the backend (HTTP only)
+- `custom_headers` (Map of String, Sensitive) Extra headers sent to the backend (HTTP only). Marked sensitive since values commonly carry credentials, e.g. an `Authorization` header.
 - `path_rewrite` (String) Controls how the request path is rewritten before forwarding (HTTP only)
 - `proxy_protocol` (Boolean) Send PROXY Protocol v2 header to this backend (TCP/TLS only)
 - `request_timeout` (String) Per-target response timeout as a Go duration string

--- a/docs/resources/reverse_proxy_service.md
+++ b/docs/resources/reverse_proxy_service.md
@@ -255,7 +255,7 @@ Optional:
 
 Optional:
 
-- `custom_headers` (Map of String) Extra headers sent to the backend (HTTP only)
+- `custom_headers` (Map of String, Sensitive) Extra headers sent to the backend (HTTP only). Marked sensitive since values commonly carry credentials, e.g. an `Authorization` header.
 - `path_rewrite` (String) Controls how the request path is rewritten before forwarding. Default strips the matched prefix. "preserve" keeps the full original path. (HTTP only)
 - `proxy_protocol` (Boolean) Send PROXY Protocol v2 header to this backend (TCP/TLS only)
 - `request_timeout` (String) Per-target response timeout as a Go duration string (e.g. "30s", "2m")

--- a/internal/provider/reverse_proxy_service_data_source.go
+++ b/internal/provider/reverse_proxy_service_data_source.go
@@ -140,9 +140,10 @@ func (d *ReverseProxyServiceDataSource) Schema(ctx context.Context, req datasour
 									Computed:            true,
 								},
 								"custom_headers": schema.MapAttribute{
-									MarkdownDescription: "Extra headers sent to the backend (HTTP only)",
+									MarkdownDescription: "Extra headers sent to the backend (HTTP only). Marked sensitive since values commonly carry credentials, e.g. an `Authorization` header.",
 									Computed:            true,
 									ElementType:         types.StringType,
+									Sensitive:           true,
 								},
 								"proxy_protocol": schema.BoolAttribute{
 									MarkdownDescription: "Send PROXY Protocol v2 header to this backend (TCP/TLS only)",

--- a/internal/provider/reverse_proxy_service_resource.go
+++ b/internal/provider/reverse_proxy_service_resource.go
@@ -347,9 +347,10 @@ func (r *ReverseProxyService) Schema(ctx context.Context, req resource.SchemaReq
 									Validators:          []validator.String{stringvalidator.OneOf("preserve")},
 								},
 								"custom_headers": schema.MapAttribute{
-									MarkdownDescription: "Extra headers sent to the backend (HTTP only)",
+									MarkdownDescription: "Extra headers sent to the backend (HTTP only). Marked sensitive since values commonly carry credentials, e.g. an `Authorization` header.",
 									Optional:            true,
 									ElementType:         types.StringType,
+									Sensitive:           true,
 								},
 								"proxy_protocol": schema.BoolAttribute{
 									MarkdownDescription: "Send PROXY Protocol v2 header to this backend (TCP/TLS only)",


### PR DESCRIPTION
## Summary

This PR originally added `custom_headers` support to reverse proxy service targets (flat at the target level). While it was open, #132 landed the full nested `targets[].options` block — including `custom_headers` — with acceptance coverage under the new e2e harness, superseding the original change. The branch has been rebuilt on top of latest `main` accordingly.

What remains from #189 is the sensitivity concern: the primary use case for custom headers is injecting credentials toward the backend (e.g. a Basic or Bearer `Authorization` header), and today the values are shown in plain text in plans and logs.

## Changes

- Mark `targets[].options.custom_headers` as `Sensitive` on both the `netbird_reverse_proxy_service` resource and data source.
- Regenerate docs.

## Testing

- `go build`, `go vet`, and full provider unit tests pass. No behavior change beyond plan/log redaction; the existing `custom_headers` acceptance coverage from #132 exercises the attribute under the e2e harness.

Completes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reverse proxy services now support configurable modes, listen ports, automatic port assignment, access restrictions, and header authentication.
  * Added per-target options, including custom headers and expanded TCP/UDP protocol support.
  * Custom header values are treated as sensitive, including credentials such as authorization tokens.
  * Service and target settings are now preserved and reported consistently.

* **Documentation**
  * Updated data source and resource documentation to describe sensitive custom headers and supported configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->