### PR TITLE
[provider] Follow the Agent Network gateway API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,11 +80,8 @@ jobs:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - run: go mod download
-      # Needs the never-bootstrapped account, so it runs before the suite bootstraps it.
-      - env:
-          TF_ACC: "1"
-        run: go test -v -run Test_AgentNetworkSettings_BootstrapViaCluster ./internal/provider/
-        timeout-minutes: 5
+      # The gateway bootstrap tests release the account's gateway themselves, so
+      # they no longer have to run before anything else in their own invocation.
       - env:
           TF_ACC: "1"
         run: go test -v -cover ./internal/provider/

--- a/docs/data-sources/agent_network_provider.md
+++ b/docs/data-sources/agent_network_provider.md
@@ -29,7 +29,6 @@ data "netbird_agent_network_provider" "openai" {
 ### Read-Only
 
 - `api_key` (String, Sensitive) Not returned by the API (sealed at rest)
-- `bootstrap_cluster` (String) Bootstrap cluster (only relevant on create)
 - `enabled` (Boolean) Whether the provider is enabled
 - `extra_values` (Map of String) Catalog-specific extra header values
 - `identity_header_groups` (String) Wire header for caller groups

--- a/docs/resources/agent_network_provider.md
+++ b/docs/resources/agent_network_provider.md
@@ -13,19 +13,17 @@ Manage Agent Network providers (upstream AI API endpoints), see [NetBird Docs](h
 ## Example Usage
 
 ```terraform
-# The account's Agent Network settings row — which supplies the endpoint agents
-# call — is created only when a provider is created with `bootstrap_cluster` set.
-# Creating providers without it leaves the account unbootstrapped, so set it on
-# at least the first provider. It is ignored once the account is bootstrapped.
-data "netbird_reverse_proxy_clusters" "all" {}
-
+# The account needs an Agent Network gateway before agents have anywhere to send
+# traffic, and creating a provider does not make one. Bootstrap it with a
+# netbird_agent_network_settings resource (see its example) and depend on it, so
+# the endpoint exists before the provider that routes through it.
 resource "netbird_agent_network_provider" "openai" {
   provider_id  = "openai_api"
   name         = "OpenAI Production"
   upstream_url = "https://api.openai.com"
   api_key      = var.openai_api_key
 
-  bootstrap_cluster = data.netbird_reverse_proxy_clusters.all.clusters[0].address
+  depends_on = [netbird_agent_network_settings.main]
 
   models = [
     {
@@ -54,7 +52,6 @@ resource "netbird_agent_network_provider" "openai" {
 
 ### Optional
 
-- `bootstrap_cluster` (String) Proxy cluster that fronts this account's Agent Network endpoint. Setting this on a provider create bootstraps the account's Agent Network settings row (cluster, subdomain and endpoint); **an account with no providers created with `bootstrap_cluster` set is never bootstrapped**, leaving agents with no endpoint to call and `netbird_agent_network_settings` unmanageable. Ignored once the account is bootstrapped, and on all updates. Use the `netbird_reverse_proxy_clusters` data source to find valid cluster addresses.
 - `enabled` (Boolean) Whether the provider is enabled
 - `extra_values` (Map of String) Catalog-specific extra header values (e.g. `x-portkey-config` for Portkey gateways). Omit to leave the stored values unchanged. Empty values are dropped by the API.
 - `identity_header_groups` (String) Wire header name the proxy stamps with the caller's NetBird groups as a comma-separated list

--- a/docs/resources/agent_network_settings.md
+++ b/docs/resources/agent_network_settings.md
@@ -3,21 +3,43 @@
 page_title: "netbird_agent_network_settings Resource - netbird"
 subcategory: ""
 description: |-
-  Manage account-level Agent Network gateway settings (log collection, prompt capture, PII redaction). Setting cluster bootstraps the account when it has no settings row yet; cluster and subdomain are immutable once assigned.
+  Manage the account's Agent Network gateway: the endpoint agents call, and the collection settings (log collection, prompt capture, PII redaction).
+  Set exactly one of proxy_address or endpoint to bootstrap an account that has none yet. proxy_address allocates a hostname one label beneath a shared proxy cluster; endpoint claims a hostname outright, served by a proxy dedicated to this account. Both are assigned once and immutable afterwards, so changing either replaces the resource: the endpoint is released and a new one allocated. Omit both to adopt whatever the account already has.
 ---
 
 # netbird_agent_network_settings (Resource)
 
-Manage account-level Agent Network gateway settings (log collection, prompt capture, PII redaction). Setting `cluster` bootstraps the account when it has no settings row yet; cluster and subdomain are immutable once assigned.
+Manage the account's Agent Network gateway: the endpoint agents call, and the collection settings (log collection, prompt capture, PII redaction).
+
+Set exactly one of `proxy_address` or `endpoint` to bootstrap an account that has none yet. `proxy_address` allocates a hostname one label beneath a shared proxy cluster; `endpoint` claims a hostname outright, served by a proxy dedicated to this account. Both are assigned once and immutable afterwards, so changing either replaces the resource: the endpoint is released and a new one allocated. Omit both to adopt whatever the account already has.
 
 ## Example Usage
 
 ```terraform
+# Bootstrapping the account's Agent Network gateway. Set exactly one address:
+#
+#   proxy_address — allocate an endpoint one label beneath a shared proxy
+#                   cluster, which is the usual choice.
+#   endpoint      — claim a hostname outright, served by a proxy dedicated to
+#                   this account.
+#
+# Both are assigned once and immutable afterwards, so changing either replaces
+# the resource: the endpoint is released and a new one allocated, which requires
+# the account's Agent Network providers to be destroyed first.
+data "netbird_reverse_proxy_clusters" "all" {}
+
 resource "netbird_agent_network_settings" "main" {
+  proxy_address = data.netbird_reverse_proxy_clusters.all.clusters[0].address
+
   enable_log_collection     = true
   enable_prompt_collection  = false
   redact_pii                = false
   access_log_retention_days = 90
+}
+
+# The hostname agents are configured with.
+output "agent_network_endpoint" {
+  value = netbird_agent_network_settings.main.endpoint
 }
 ```
 
@@ -27,12 +49,12 @@ resource "netbird_agent_network_settings" "main" {
 ### Optional
 
 - `access_log_retention_days` (Number) Days to retain full access-log rows (0 or less = keep indefinitely). Omit to leave the account's current value unchanged.
-- `cluster` (String) Proxy cluster address fronting this account's agent-network endpoint. Set it to bootstrap the account when it has no Agent Network settings row yet — the `netbird_reverse_proxy_clusters` data source lists valid addresses. Immutable once assigned: changing it is rejected at plan time, since the settings row cannot be deleted or re-created on another cluster. Omit to adopt the cluster assigned when a provider was created with `bootstrap_cluster`.
 - `enable_log_collection` (Boolean) Collect per-request access-log entries for this account. Omit to leave the account's current value unchanged.
 - `enable_prompt_collection` (Boolean) Master switch for request/response prompt capture (effective only when a policy guardrail also enables it). Omit to leave the account's current value unchanged.
+- `endpoint` (String) Hostname agents call for this account. Set it to claim that hostname outright, which makes the gateway dedicated: only a proxy declaring exactly this address serves it, and it is rejected when another account already holds it. Mutually exclusive with `proxy_address`. Assigned by the server when `proxy_address` is used instead. Immutable once assigned: changing it releases the current endpoint and allocates anew, which requires the account's Agent Network providers to be destroyed first.
+- `proxy_address` (String) Cluster address of the proxy serving this account's gateway. Set it to allocate an endpoint one label beneath a shared cluster — the `netbird_reverse_proxy_clusters` data source lists valid addresses. Mutually exclusive with `endpoint`, and equal to it when the gateway is dedicated. Immutable once assigned, with the same replacement semantics as `endpoint`.
 - `redact_pii` (Boolean) Redact PII from captured prompts. Omit to leave the account's current value unchanged.
 
 ### Read-Only
 
-- `endpoint` (String) Full agent-network endpoint hostname (`<subdomain>.<cluster>`), read-only
-- `subdomain` (String) DNS-safe subdomain prefix (read-only)
+- `dedicated` (Boolean) Whether a proxy dedicated to this account serves the gateway, which is the case when `endpoint` and `proxy_address` are the same address (read-only).

--- a/examples/resources/netbird_agent_network_provider/resource.tf
+++ b/examples/resources/netbird_agent_network_provider/resource.tf
@@ -1,16 +1,14 @@
-# The account's Agent Network settings row — which supplies the endpoint agents
-# call — is created only when a provider is created with `bootstrap_cluster` set.
-# Creating providers without it leaves the account unbootstrapped, so set it on
-# at least the first provider. It is ignored once the account is bootstrapped.
-data "netbird_reverse_proxy_clusters" "all" {}
-
+# The account needs an Agent Network gateway before agents have anywhere to send
+# traffic, and creating a provider does not make one. Bootstrap it with a
+# netbird_agent_network_settings resource (see its example) and depend on it, so
+# the endpoint exists before the provider that routes through it.
 resource "netbird_agent_network_provider" "openai" {
   provider_id  = "openai_api"
   name         = "OpenAI Production"
   upstream_url = "https://api.openai.com"
   api_key      = var.openai_api_key
 
-  bootstrap_cluster = data.netbird_reverse_proxy_clusters.all.clusters[0].address
+  depends_on = [netbird_agent_network_settings.main]
 
   models = [
     {

--- a/examples/resources/netbird_agent_network_settings/resource.tf
+++ b/examples/resources/netbird_agent_network_settings/resource.tf
@@ -1,6 +1,25 @@
+# Bootstrapping the account's Agent Network gateway. Set exactly one address:
+#
+#   proxy_address — allocate an endpoint one label beneath a shared proxy
+#                   cluster, which is the usual choice.
+#   endpoint      — claim a hostname outright, served by a proxy dedicated to
+#                   this account.
+#
+# Both are assigned once and immutable afterwards, so changing either replaces
+# the resource: the endpoint is released and a new one allocated, which requires
+# the account's Agent Network providers to be destroyed first.
+data "netbird_reverse_proxy_clusters" "all" {}
+
 resource "netbird_agent_network_settings" "main" {
+  proxy_address = data.netbird_reverse_proxy_clusters.all.clusters[0].address
+
   enable_log_collection     = true
   enable_prompt_collection  = false
   redact_pii                = false
   access_log_retention_days = 90
+}
+
+# The hostname agents are configured with.
+output "agent_network_endpoint" {
+  value = netbird_agent_network_settings.main.endpoint
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/netbirdio/netbird v0.76.2-0.20260803235909-bc7a15ab71d9
+	github.com/netbirdio/netbird v0.76.4-0.20260810175000-27b2d3f35159
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ github.com/netbirdio/dex/api/v2 v2.0.0-20260512110716-8d70ad8647c1 h1:neE7z+FPUk
 github.com/netbirdio/dex/api/v2 v2.0.0-20260512110716-8d70ad8647c1/go.mod h1:awuTyT29CYALpEyET0S307EgNlPWrc7fFKRAyhsO45M=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42 h1:F3zS5fT9xzD1OFLfcdAE+3FfyiwjGukF1hvj0jErgs8=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42/go.mod h1:n47r67ZSPgwSmT/Z1o48JjZQW9YJ6m/6Bd/uAXkL3Pg=
-github.com/netbirdio/netbird v0.76.2-0.20260803235909-bc7a15ab71d9 h1:Eg/K2zOWyd2y0GYBgjU6Ts+BdMX3xrp7dJGy/QnWnkw=
-github.com/netbirdio/netbird v0.76.2-0.20260803235909-bc7a15ab71d9/go.mod h1:rAeue0yy5JZ8sgO+cO+TuMmc7rsD9j4SGp+TRydqZUQ=
+github.com/netbirdio/netbird v0.76.4-0.20260810175000-27b2d3f35159 h1:x6ENKFcXT0h8i0xpJzrFU1G4Or1XJNtJFBCPZEmdbLY=
+github.com/netbirdio/netbird v0.76.4-0.20260810175000-27b2d3f35159/go.mod h1:LlTSuwk0F94rpMUt936KvMq6o3glHYOevyVqxqKxBfA=
 github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oapi-codegen/runtime v1.6.0 h1:7Xx+GlueD6nRuyKoCPzL434Jfi3BetbiJOrzCHp/VPU=

--- a/internal/provider/agent_network_acc_test.go
+++ b/internal/provider/agent_network_acc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -19,6 +20,35 @@ import (
 // without validating that a proxy answers there, so a placeholder is enough.
 const testProxyAddress = "acc.test.invalid"
 
+// routeMissing reports whether an error is the management server answering that
+// it does not serve an endpoint at all.
+//
+// A 404 arrives in two shapes. A handler's 404 carries a JSON body and reaches
+// the caller as a typed error; the router's carries plain text, which the REST
+// client cannot unmarshal, so it surfaces as a parse failure naming the status
+// instead. Only the second shape means the route is absent, but matching both is
+// harmless here: no endpoint this file calls answers a typed 404.
+func routeMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	return netbird.IsNotFound(err) || strings.Contains(err.Error(), "error code 404")
+}
+
+// testRequireGatewayBootstrap skips when the server does not serve the gateway
+// bootstrap endpoint, which a server predating it does not.
+//
+// The probe is a create with neither address: a server serving the route rejects
+// it with a typed 422 for the missing address, one that does not answers the
+// router's 404. Nothing is created either way, so this leaves the account alone.
+func testRequireGatewayBootstrap(t *testing.T) {
+	t.Helper()
+	_, err := testAgentNetworkClient().CreateSettings(context.Background(), api.AgentNetworkSettingsCreateRequest{})
+	if routeMissing(err) {
+		t.Skip("management server predates the Agent Network gateway bootstrap API")
+	}
+}
+
 // testBootstrapGateway makes sure the account has a gateway, which providers no
 // longer create as a side effect: bootstrapping is a settings create of its own.
 // Idempotent, so every test that needs an endpoint can call it.
@@ -28,9 +58,13 @@ func testBootstrapGateway(t *testing.T) {
 	if s, err := c.GetSettings(context.Background()); err == nil && s.Endpoint != "" {
 		return
 	}
-	if _, err := c.CreateSettings(context.Background(), api.AgentNetworkSettingsCreateRequest{
+	_, err := c.CreateSettings(context.Background(), api.AgentNetworkSettingsCreateRequest{
 		ProxyAddress: valPtr(testProxyAddress),
-	}); err != nil {
+	})
+	if routeMissing(err) {
+		t.Skip("management server predates the Agent Network gateway bootstrap API")
+	}
+	if err != nil {
 		t.Fatalf("bootstrap the agent network gateway: %v", err)
 	}
 }
@@ -53,6 +87,9 @@ func testReleaseGateway(t *testing.T) {
 		return
 	}
 	if err := c.DeleteSettings(context.Background()); err != nil {
+		if routeMissing(err) {
+			t.Skip("management server predates the Agent Network gateway bootstrap API")
+		}
 		t.Skipf("the account's gateway cannot be released: %v", err)
 	}
 }
@@ -457,6 +494,7 @@ resource "netbird_agent_network_settings" "%[1]s" {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testEnsureManagementRunning(t)
+			testRequireGatewayBootstrap(t)
 			testReleaseGateway(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -519,6 +557,7 @@ func Test_AgentNetworkSettings_BootstrapDedicatedEndpoint(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testEnsureManagementRunning(t)
+			testRequireGatewayBootstrap(t)
 			testReleaseGateway(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -563,6 +602,7 @@ func Test_AgentNetworkSettings_BootstrapRequiresAnAddress(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testEnsureManagementRunning(t)
+			testRequireGatewayBootstrap(t)
 			testReleaseGateway(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/agent_network_acc_test.go
+++ b/internal/provider/agent_network_acc_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
 	"github.com/netbirdio/netbird/shared/management/http/api"
@@ -19,6 +20,10 @@ import (
 // needs a proxy cluster address, but the server stores that string verbatim
 // without validating that a proxy answers there, so a placeholder is enough.
 const testProxyAddress = "acc.test.invalid"
+
+// movedProxyAddress is where a replacement test moves the gateway to, so the
+// endpoint it allocates is visibly beneath a different address.
+const movedProxyAddress = "moved.acc.test.invalid"
 
 // routeMissing reports whether an error is the management server answering that
 // it does not serve an endpoint at all.
@@ -530,17 +535,160 @@ resource "netbird_agent_network_settings" "%[1]s" {
 				),
 			},
 			{
-				// The addresses are assigned once. A different one has to be
-				// reported as a replacement, not applied in place.
+				// The addresses are assigned once, so a configured change is a
+				// replacement: the gateway is released and a new endpoint
+				// allocated beneath the address that was asked for. Applied
+				// rather than planned only, because the release is the half that
+				// can fail.
 				ResourceName: rName,
 				Config: fmt.Sprintf(`
 resource "netbird_agent_network_settings" "%[1]s" {
-	proxy_address         = "changed.cluster.invalid"
+	proxy_address         = "%[2]s"
 	enable_log_collection = true
 	redact_pii            = true
+}`, rName, movedProxyAddress),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rNameFull, plancheck.ResourceActionReplace),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "proxy_address", movedProxyAddress),
+					resource.TestMatchResourceAttr(rNameFull, "endpoint",
+						regexp.MustCompile(`^[^.]+\.`+regexp.QuoteMeta(movedProxyAddress)+`$`)),
+					func(s *terraform.State) error {
+						got, err := testAgentNetworkClient().GetSettings(context.Background())
+						if err != nil {
+							return err
+						}
+						if got.ProxyAddress != movedProxyAddress {
+							return fmt.Errorf("management still serves from %q after the replacement", got.ProxyAddress)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// An address interpolated from a resource that is itself being replaced is
+// unknown at plan time even when it resolves to the same string. That must not
+// replace the gateway: releasing it allocates a new endpoint beneath the cluster,
+// silently moving the hostname agents call while the address never changed.
+//
+// terraform_data stands in for any such resource: triggers_replace forces it to
+// be replaced while its output stays the value it was given.
+func Test_AgentNetworkSettings_UnknownAddressDoesNotReplace(t *testing.T) {
+	rName := "ansunk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_agent_network_settings." + rName
+
+	config := func(trigger string) string {
+		return fmt.Sprintf(`
+resource "terraform_data" "%[1]s" {
+	input            = %[2]q
+	triggers_replace = %[3]q
+}
+
+resource "netbird_agent_network_settings" "%[1]s" {
+	proxy_address = terraform_data.%[1]s.output
+}`, rName, testProxyAddress, trigger)
+	}
+
+	var bootstrapped string
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testEnsureManagementRunning(t)
+			testRequireGatewayBootstrap(t)
+			testReleaseGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       config("first"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "proxy_address", testProxyAddress),
+					func(s *terraform.State) error {
+						bootstrapped = s.RootModule().Resources[rNameFull].Primary.Attributes["endpoint"]
+						if bootstrapped == "" {
+							return fmt.Errorf("no endpoint recorded after the bootstrap")
+						}
+						return nil
+					},
+				),
+			},
+			{
+				// The trigger changes, so terraform_data is replaced and its
+				// output is unknown while planning. The address it resolves to is
+				// the same, so the gateway has to survive.
+				ResourceName: rName,
+				Config:       config("second"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rNameFull, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					func(s *terraform.State) error {
+						got := s.RootModule().Resources[rNameFull].Primary.Attributes["endpoint"]
+						if got != bootstrapped {
+							return fmt.Errorf("the gateway was reallocated: endpoint was %q, now %q", bootstrapped, got)
+						}
+						current, err := testAgentNetworkClient().GetSettings(context.Background())
+						if err != nil {
+							return err
+						}
+						if current.Endpoint != bootstrapped {
+							return fmt.Errorf("management holds endpoint %q, expected the original %q", current.Endpoint, bootstrapped)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// The two addresses are mutually exclusive, and saying so at plan time names the
+// real problem instead of letting the apply report a missing bootstrap address.
+func Test_AgentNetworkSettings_BothAddressesRejected(t *testing.T) {
+	rName := "ansboth" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config: fmt.Sprintf(`
+resource "netbird_agent_network_settings" "%[1]s" {
+	endpoint      = "gw.acc.test.invalid"
+	proxy_address = "acc.test.invalid"
 }`, rName),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: true,
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Combination|cannot be specified when`),
+			},
+		},
+	})
+}
+
+// The server stores an address lowercased and trimmed, so a configured value that
+// is not already in that shape has to be refused rather than applied and then
+// reported back differently.
+func Test_AgentNetworkSettings_AddressMustBeNormalized(t *testing.T) {
+	rName := "ansnorm" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config: fmt.Sprintf(`
+resource "netbird_agent_network_settings" "%[1]s" {
+	proxy_address = "Acc.Test.INVALID"
+}`, rName),
+				ExpectError: regexp.MustCompile(`must be a lowercase hostname`),
 			},
 		},
 	})

--- a/internal/provider/agent_network_acc_test.go
+++ b/internal/provider/agent_network_acc_test.go
@@ -14,10 +14,48 @@ import (
 )
 
 // The acceptance tests below run against the dockerized management server
-// started by testEnsureManagementRunning. Agent Network needs a proxy cluster
-// address to bootstrap the account's settings row, but the server stores that
-// string verbatim without validating it, so a placeholder is enough.
-const testBootstrapCluster = "acc.test.invalid"
+// started by testEnsureManagementRunning. Bootstrapping the account's gateway
+// needs a proxy cluster address, but the server stores that string verbatim
+// without validating that a proxy answers there, so a placeholder is enough.
+const testProxyAddress = "acc.test.invalid"
+
+// testBootstrapGateway makes sure the account has a gateway, which providers no
+// longer create as a side effect: bootstrapping is a settings create of its own.
+// Idempotent, so every test that needs an endpoint can call it.
+func testBootstrapGateway(t *testing.T) {
+	t.Helper()
+	c := testAgentNetworkClient()
+	if s, err := c.GetSettings(context.Background()); err == nil && s.Endpoint != "" {
+		return
+	}
+	if _, err := c.CreateSettings(context.Background(), api.AgentNetworkSettingsCreateRequest{
+		ProxyAddress: valPtr(testProxyAddress),
+	}); err != nil {
+		t.Fatalf("bootstrap the agent network gateway: %v", err)
+	}
+}
+
+// testReleaseGateway takes the account back to having no gateway, so a bootstrap
+// test exercises the create path whatever ran before it. Releasing is refused
+// while providers still route through the gateway; a test that finds the account
+// in that state has nothing it can do, so it skips.
+func testReleaseGateway(t *testing.T) {
+	t.Helper()
+	c := testAgentNetworkClient()
+	s, err := c.GetSettings(context.Background())
+	if err != nil {
+		if netbird.IsNotFound(err) {
+			t.Skip("management server predates the agent-network settings defaults contract")
+		}
+		t.Fatalf("read agent network settings: %v", err)
+	}
+	if s.Endpoint == "" {
+		return
+	}
+	if err := c.DeleteSettings(context.Background()); err != nil {
+		t.Skipf("the account's gateway cannot be released: %v", err)
+	}
+}
 
 func testAgentNetworkClient() *netbird.AgentNetworkAPI {
 	return testClient().AgentNetwork
@@ -33,10 +71,9 @@ func testAgentNetworkProviderResource(rName, name, extraValues, metadataDisabled
 	name              = "%s"
 	upstream_url      = "https://api.openai.com"
 	api_key           = "sk-acc-test"
-	bootstrap_cluster = "%s"
 	extra_values      = %s
 	metadata_disabled = %s
-}`, rName, name, testBootstrapCluster, extraValues, metadataDisabled)
+}`, rName, name, extraValues, metadataDisabled)
 }
 
 func Test_AgentNetworkProvider_Create(t *testing.T) {
@@ -130,8 +167,7 @@ func Test_AgentNetworkProvider_ProviderIdUpdatesInPlace(t *testing.T) {
 	name              = "%s"
 	upstream_url      = "%s"
 	api_key           = "sk-acc-test"
-	bootstrap_cluster = "%s"
-}`, rName, providerID, rName, upstream, testBootstrapCluster)
+}`, rName, providerID, rName, upstream)
 	}
 
 	var firstID string
@@ -222,7 +258,6 @@ resource "netbird_agent_network_provider" "%[1]s" {
 	name              = "%[1]s-provider"
 	upstream_url      = "https://api.openai.com"
 	api_key           = "sk-acc-test"
-	bootstrap_cluster = "%[2]s"
 }
 
 resource "netbird_agent_network_guardrail" "%[1]s" {
@@ -247,7 +282,7 @@ resource "netbird_agent_network_policy" "%[1]s" {
 		group_cap      = 1000000
 		window_seconds = 86400
 	}
-}`, rName, testBootstrapCluster)
+}`, rName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
@@ -334,34 +369,41 @@ func Test_AgentNetworkSettings_AdoptsExistingValues(t *testing.T) {
 	rName := "ans" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_agent_network_settings." + rName
 
-	// The provider create bootstraps the settings row, which the server seeds
-	// with log collection enabled. The settings resource manages only the
-	// retention, so log collection must survive.
+	// The account's gateway is bootstrapped with log collection enabled. This
+	// resource manages only the retention, so log collection must survive.
+	//
+	// The provider depends on the settings, not the other way round: the server
+	// refuses to release a gateway while providers still route through it, so the
+	// gateway has to be created first and destroyed last.
 	config := fmt.Sprintf(`
+resource "netbird_agent_network_settings" "%[1]s" {
+	access_log_retention_days = 45
+}
+
 resource "netbird_agent_network_provider" "%[1]s" {
 	provider_id       = "openai_api"
 	name              = "%[1]s-provider"
 	upstream_url      = "https://api.openai.com"
 	api_key           = "sk-acc-test"
-	bootstrap_cluster = "%[2]s"
-}
-
-resource "netbird_agent_network_settings" "%[1]s" {
-	access_log_retention_days = 45
-	depends_on                = [netbird_agent_network_provider.%[1]s]
-}`, rName, testBootstrapCluster)
+	depends_on        = [netbird_agent_network_settings.%[1]s]
+}`, rName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testEnsureManagementRunning(t)
+			// The settings resource adopts an existing gateway rather than
+			// creating one, so the account needs to have been bootstrapped.
+			testBootstrapGateway(t)
 			// Normalize the singleton so the assertion does not depend on
-			// whatever a previous run left behind.
+			// whatever a previous run left behind. The addresses are echoed
+			// because the update requires them unchanged.
 			c := testAgentNetworkClient()
 			if cur, err := c.GetSettings(context.Background()); err == nil && !cur.EnableLogCollection {
-				retention := 30
 				if _, err := c.UpdateSettings(context.Background(), api.AgentNetworkSettingsRequest{
+					Endpoint:               cur.Endpoint,
+					ProxyAddress:           cur.ProxyAddress,
 					EnableLogCollection:    true,
-					AccessLogRetentionDays: &retention,
+					AccessLogRetentionDays: 30,
 				}); err != nil {
 					t.Fatalf("failed to normalize agent-network settings: %v", err)
 				}
@@ -396,38 +438,26 @@ resource "netbird_agent_network_settings" "%[1]s" {
 	})
 }
 
-// Test_AgentNetworkSettings_BootstrapViaCluster covers the settings-first
-// bootstrap path: a settings resource carrying `cluster` creates the
-// account's settings row without any provider existing. It needs a
-// management server with the settings-defaults contract AND an account that
-// has never been bootstrapped, so it self-skips against older servers (where
-// the unbootstrapped read surfaces as not-found) and on accounts a previous
-// test already bootstrapped — on a fresh compose environment it runs when
-// scheduled before the provider tests.
-func Test_AgentNetworkSettings_BootstrapViaCluster(t *testing.T) {
+// Test_AgentNetworkSettings_BootstrapViaProxyAddress covers the bootstrap path:
+// a settings resource carrying `proxy_address` creates the account's gateway,
+// allocating an endpoint one label beneath that cluster. Nothing else bootstraps
+// an account, so the gateway is released first and the create path is what runs,
+// whatever ran before this test.
+func Test_AgentNetworkSettings_BootstrapViaProxyAddress(t *testing.T) {
 	rName := "ansboot" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_agent_network_settings." + rName
 
 	config := fmt.Sprintf(`
 resource "netbird_agent_network_settings" "%[1]s" {
-	cluster               = "%[2]s"
+	proxy_address         = "%[2]s"
 	enable_log_collection = true
 	redact_pii            = true
-}`, rName, testBootstrapCluster)
+}`, rName, testProxyAddress)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testEnsureManagementRunning(t)
-			s, err := testAgentNetworkClient().GetSettings(context.Background())
-			if err != nil {
-				if netbird.IsNotFound(err) {
-					t.Skip("management server predates the agent-network settings defaults contract")
-				}
-				t.Fatalf("failed to read agent-network settings: %v", err)
-			}
-			if s.Endpoint != "" {
-				t.Skip("account already bootstrapped; the settings cluster bootstrap needs a fresh account")
-			}
+			testReleaseGateway(t)
 		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -435,10 +465,11 @@ resource "netbird_agent_network_settings" "%[1]s" {
 				ResourceName: rName,
 				Config:       config,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(rNameFull, "cluster", testBootstrapCluster),
-					resource.TestCheckResourceAttrSet(rNameFull, "subdomain"),
+					resource.TestCheckResourceAttr(rNameFull, "proxy_address", testProxyAddress),
+					// An endpoint beneath a shared cluster, so not dedicated.
+					resource.TestCheckResourceAttr(rNameFull, "dedicated", "false"),
 					resource.TestMatchResourceAttr(rNameFull, "endpoint",
-						regexp.MustCompile(`\.`+regexp.QuoteMeta(testBootstrapCluster)+`$`)),
+						regexp.MustCompile(`^[^.]+\.`+regexp.QuoteMeta(testProxyAddress)+`$`)),
 					resource.TestCheckResourceAttr(rNameFull, "enable_log_collection", "true"),
 					resource.TestCheckResourceAttr(rNameFull, "redact_pii", "true"),
 					func(s *terraform.State) error {
@@ -446,28 +477,103 @@ resource "netbird_agent_network_settings" "%[1]s" {
 						if err != nil {
 							return err
 						}
-						if got.Cluster != testBootstrapCluster {
-							return fmt.Errorf("cluster not pinned by the settings bootstrap, found %q", got.Cluster)
+						if got.ProxyAddress != testProxyAddress {
+							return fmt.Errorf("proxy address not pinned by the bootstrap, found %q", got.ProxyAddress)
 						}
 						if got.Endpoint == "" {
 							return fmt.Errorf("account still reads as unbootstrapped after the settings apply")
+						}
+						attrs := s.RootModule().Resources[rNameFull].Primary.Attributes
+						if attrs["endpoint"] != got.Endpoint {
+							return fmt.Errorf("endpoint mismatch: state %q, API %q", attrs["endpoint"], got.Endpoint)
 						}
 						return nil
 					},
 				),
 			},
 			{
-				// The cluster is pinned for good: a change must fail at plan
-				// time, before any destroy or API call can run.
+				// The addresses are assigned once. A different one has to be
+				// reported as a replacement, not applied in place.
 				ResourceName: rName,
 				Config: fmt.Sprintf(`
 resource "netbird_agent_network_settings" "%[1]s" {
-	cluster               = "changed.cluster.invalid"
+	proxy_address         = "changed.cluster.invalid"
 	enable_log_collection = true
 	redact_pii            = true
 }`, rName),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`Cluster is immutable once assigned`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// A gateway can also be claimed by hostname, which makes it dedicated: the proxy
+// at that address is the account's gateway, so endpoint and proxy_address are the
+// same. Only reachable on an account with no gateway yet.
+func Test_AgentNetworkSettings_BootstrapDedicatedEndpoint(t *testing.T) {
+	rName := "ansded" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_agent_network_settings." + rName
+	endpoint := rName + ".acc.test.invalid"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testEnsureManagementRunning(t)
+			testReleaseGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config: fmt.Sprintf(`
+resource "netbird_agent_network_settings" "%[1]s" {
+	endpoint = "%[2]s"
+}`, rName, endpoint),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "endpoint", endpoint),
+					// A claimed hostname is served by a proxy declaring exactly
+					// that address, so the two addresses coincide.
+					resource.TestCheckResourceAttr(rNameFull, "proxy_address", endpoint),
+					resource.TestCheckResourceAttr(rNameFull, "dedicated", "true"),
+					func(s *terraform.State) error {
+						got, err := testAgentNetworkClient().GetSettings(context.Background())
+						if err != nil {
+							return err
+						}
+						if got.Endpoint != endpoint || got.ProxyAddress != endpoint {
+							return fmt.Errorf("management holds endpoint %q / proxy address %q, expected both to be %q",
+								got.Endpoint, got.ProxyAddress, endpoint)
+						}
+						if !got.Dedicated {
+							return fmt.Errorf("a self-addressed gateway should report dedicated")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// Bootstrapping needs one of the two addresses. Without either, the apply has to
+// say so rather than reach an API that would refuse it.
+func Test_AgentNetworkSettings_BootstrapRequiresAnAddress(t *testing.T) {
+	rName := "ansreq" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testEnsureManagementRunning(t)
+			testReleaseGateway(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config: fmt.Sprintf(`
+resource "netbird_agent_network_settings" "%[1]s" {
+	enable_log_collection = true
+}`, rName),
+				ExpectError: regexp.MustCompile(`Agent Network not bootstrapped`),
 			},
 		},
 	})

--- a/internal/provider/agent_network_provider_data_source.go
+++ b/internal/provider/agent_network_provider_data_source.go
@@ -55,10 +55,6 @@ func (d *AgentNetworkProviderDataSource) Schema(_ context.Context, _ datasource.
 				Computed:            true,
 				Sensitive:           true,
 			},
-			"bootstrap_cluster": schema.StringAttribute{
-				MarkdownDescription: "Bootstrap cluster (only relevant on create)",
-				Computed:            true,
-			},
 			"enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether the provider is enabled",
 				Computed:            true,

--- a/internal/provider/agent_network_provider_resource.go
+++ b/internal/provider/agent_network_provider_resource.go
@@ -39,7 +39,6 @@ type AgentNetworkProviderModel struct {
 	Name                 types.String `tfsdk:"name"`
 	UpstreamUrl          types.String `tfsdk:"upstream_url"`
 	ApiKey               types.String `tfsdk:"api_key"`
-	BootstrapCluster     types.String `tfsdk:"bootstrap_cluster"`
 	Enabled              types.Bool   `tfsdk:"enabled"`
 	SkipTlsVerification  types.Bool   `tfsdk:"skip_tls_verification"`
 	IdentityHeaderUserId types.String `tfsdk:"identity_header_user_id"`
@@ -97,14 +96,6 @@ func (r *AgentNetworkProvider) Schema(_ context.Context, _ resource.SchemaReques
 				MarkdownDescription: "Upstream provider API key. Sealed at rest; never returned in responses. Required on create; omit on update to keep the existing key.",
 				Required:            true,
 				Sensitive:           true,
-			},
-			"bootstrap_cluster": schema.StringAttribute{
-				MarkdownDescription: "Proxy cluster that fronts this account's Agent Network endpoint. Setting this on a provider create " +
-					"bootstraps the account's Agent Network settings row (cluster, subdomain and endpoint); **an account with no " +
-					"providers created with `bootstrap_cluster` set is never bootstrapped**, leaving agents with no endpoint to call " +
-					"and `netbird_agent_network_settings` unmanageable. Ignored once the account is bootstrapped, and on all updates. " +
-					"Use the `netbird_reverse_proxy_clusters` data source to find valid cluster addresses.",
-				Optional: true,
 			},
 			"enabled": schema.BoolAttribute{
 				MarkdownDescription: "Whether the provider is enabled",
@@ -227,9 +218,6 @@ func agentNetworkProviderTerraformToRequest(ctx context.Context, data *AgentNetw
 	if !data.ApiKey.IsNull() && !data.ApiKey.IsUnknown() {
 		req.ApiKey = data.ApiKey.ValueStringPointer()
 	}
-	if !data.BootstrapCluster.IsNull() && !data.BootstrapCluster.IsUnknown() {
-		req.BootstrapCluster = data.BootstrapCluster.ValueStringPointer()
-	}
 	if !data.IdentityHeaderUserId.IsNull() && !data.IdentityHeaderUserId.IsUnknown() {
 		req.IdentityHeaderUserId = data.IdentityHeaderUserId.ValueStringPointer()
 	}
@@ -284,7 +272,7 @@ func (r *AgentNetworkProvider) Create(ctx context.Context, req resource.CreateRe
 		resp.Diagnostics.AddError("Error creating Agent Network Provider", err.Error())
 		return
 	}
-	r.warnIfAccountUnbootstrapped(ctx, &data, &resp.Diagnostics)
+	r.warnIfAccountUnbootstrapped(ctx, &resp.Diagnostics)
 	resp.Diagnostics.Append(agentNetworkProviderAPIToTerraform(ctx, p, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -293,16 +281,10 @@ func (r *AgentNetworkProvider) Create(ctx context.Context, req resource.CreateRe
 }
 
 // warnIfAccountUnbootstrapped flags the silent dead end where providers exist but
-// the account has no agent-network settings row, so there is no endpoint for
-// agents to call. The server only bootstraps that row when a provider is created
-// with bootstrap_cluster set, and it reports failures at debug level only, so
-// without this the misconfiguration is invisible until the settings resource
-// errors out. Only checked when bootstrap_cluster was omitted, so accounts that
-// are already bootstrapped (where the field is ignored) stay quiet.
-func (r *AgentNetworkProvider) warnIfAccountUnbootstrapped(ctx context.Context, data *AgentNetworkProviderModel, diags *diag.Diagnostics) {
-	if !data.BootstrapCluster.IsNull() && !data.BootstrapCluster.IsUnknown() && data.BootstrapCluster.ValueString() != "" {
-		return
-	}
+// the account has no Agent Network gateway, so there is no endpoint for agents to
+// call. Creating a provider no longer bootstraps one, so without this the
+// misconfiguration is invisible until an agent has nowhere to connect.
+func (r *AgentNetworkProvider) warnIfAccountUnbootstrapped(ctx context.Context, diags *diag.Diagnostics) {
 	settings, err := r.client.GetSettings(ctx)
 	if err != nil && !netbird.IsNotFound(err) {
 		// The check itself failed — this is advisory only and must never
@@ -317,10 +299,10 @@ func (r *AgentNetworkProvider) warnIfAccountUnbootstrapped(ctx context.Context, 
 	}
 	diags.AddWarning(
 		"Agent Network account not bootstrapped",
-		"This provider was created but the account has no Agent Network settings row, so there is no "+
-			"endpoint for agents to call. Set `bootstrap_cluster` on an Agent Network provider or `cluster` "+
-			"on a netbird_agent_network_settings resource to bootstrap the account; the "+
-			"`netbird_reverse_proxy_clusters` data source lists valid cluster addresses.",
+		"This provider was created but the account has no Agent Network gateway, so there is no endpoint for "+
+			"agents to call. Add a netbird_agent_network_settings resource with `proxy_address` set, to allocate an "+
+			"endpoint beneath a shared proxy cluster, or `endpoint` set, to claim a hostname served by a dedicated "+
+			"proxy; the `netbird_reverse_proxy_clusters` data source lists cluster addresses.",
 	)
 }
 

--- a/internal/provider/agent_network_settings_resource.go
+++ b/internal/provider/agent_network_settings_resource.go
@@ -23,8 +23,7 @@ import (
 )
 
 var (
-	_ resource.Resource               = &AgentNetworkSettings{}
-	_ resource.ResourceWithModifyPlan = &AgentNetworkSettings{}
+	_ resource.Resource = &AgentNetworkSettings{}
 )
 
 func NewAgentNetworkSettings() resource.Resource {
@@ -35,12 +34,13 @@ type AgentNetworkSettings struct {
 	client *netbird.AgentNetworkAPI
 }
 
-// AgentNetworkSettingsModel mirrors the mutable + read-only fields of AgentNetworkSettings.
+// AgentNetworkSettingsModel mirrors the identity, mutable and read-only fields of
+// AgentNetworkSettings.
 type AgentNetworkSettingsModel struct {
-	// computed / read-only
-	Cluster   types.String `tfsdk:"cluster"`
-	Subdomain types.String `tfsdk:"subdomain"`
-	Endpoint  types.String `tfsdk:"endpoint"`
+	// identity — assigned at bootstrap, immutable afterwards
+	Endpoint     types.String `tfsdk:"endpoint"`
+	ProxyAddress types.String `tfsdk:"proxy_address"`
+	Dedicated    types.Bool   `tfsdk:"dedicated"`
 	// mutable
 	EnableLogCollection    types.Bool  `tfsdk:"enable_log_collection"`
 	EnablePromptCollection types.Bool  `tfsdk:"enable_prompt_collection"`
@@ -54,26 +54,50 @@ func (r *AgentNetworkSettings) Metadata(_ context.Context, req resource.Metadata
 
 func (r *AgentNetworkSettings) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage account-level Agent Network gateway settings (log collection, prompt capture, PII redaction). Setting `cluster` bootstraps the account when it has no settings row yet; cluster and subdomain are immutable once assigned.",
+		MarkdownDescription: "Manage the account's Agent Network gateway: the endpoint agents call, and the collection " +
+			"settings (log collection, prompt capture, PII redaction).\n\n" +
+			"Set exactly one of `proxy_address` or `endpoint` to bootstrap an account that has none yet. " +
+			"`proxy_address` allocates a hostname one label beneath a shared proxy cluster; `endpoint` claims a " +
+			"hostname outright, served by a proxy dedicated to this account. Both are assigned once and immutable " +
+			"afterwards, so changing either replaces the resource: the endpoint is released and a new one allocated. " +
+			"Omit both to adopt whatever the account already has.",
 		Attributes: map[string]schema.Attribute{
-			"cluster": schema.StringAttribute{
-				MarkdownDescription: "Proxy cluster address fronting this account's agent-network endpoint. Set it to bootstrap the account when it has no Agent Network settings row yet — the `netbird_reverse_proxy_clusters` data source lists valid addresses. Immutable once assigned: changing it is rejected at plan time, since the settings row cannot be deleted or re-created on another cluster. Omit to adopt the cluster assigned when a provider was created with `bootstrap_cluster`.",
-				Optional:            true,
-				Computed:            true,
-				Validators:          []validator.String{stringvalidator.LengthAtLeast(1)},
+			"endpoint": schema.StringAttribute{
+				MarkdownDescription: "Hostname agents call for this account. Set it to claim that hostname outright, " +
+					"which makes the gateway dedicated: only a proxy declaring exactly this address serves it, and it " +
+					"is rejected when another account already holds it. Mutually exclusive with `proxy_address`. " +
+					"Assigned by the server when `proxy_address` is used instead. Immutable once assigned: changing it " +
+					"releases the current endpoint and allocates anew, which requires the account's Agent Network " +
+					"providers to be destroyed first.",
+				Optional:   true,
+				Computed:   true,
+				Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+					// Only a configured change forces a replacement: once the
+					// server has assigned an endpoint, state carries it and a
+					// configuration that omits it must keep it.
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
-			"subdomain": schema.StringAttribute{
-				MarkdownDescription: "DNS-safe subdomain prefix (read-only)",
-				Computed:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			"proxy_address": schema.StringAttribute{
+				MarkdownDescription: "Cluster address of the proxy serving this account's gateway. Set it to allocate an " +
+					"endpoint one label beneath a shared cluster — the `netbird_reverse_proxy_clusters` data source lists " +
+					"valid addresses. Mutually exclusive with `endpoint`, and equal to it when the gateway is dedicated. " +
+					"Immutable once assigned, with the same replacement semantics as `endpoint`.",
+				Optional:   true,
+				Computed:   true,
+				Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
 			},
-			"endpoint": schema.StringAttribute{
-				MarkdownDescription: "Full agent-network endpoint hostname (`<subdomain>.<cluster>`), read-only",
-				Computed:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			"dedicated": schema.BoolAttribute{
+				MarkdownDescription: "Whether a proxy dedicated to this account serves the gateway, which is the case when " +
+					"`endpoint` and `proxy_address` are the same address (read-only).",
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 			},
 			"enable_log_collection": schema.BoolAttribute{
 				MarkdownDescription: "Collect per-request access-log entries for this account. Omit to leave the account's current value unchanged.",
@@ -103,49 +127,6 @@ func (r *AgentNetworkSettings) Schema(_ context.Context, _ resource.SchemaReques
 	}
 }
 
-// clusterChangeForbidden reports whether the plan attempts to change an
-// already-assigned cluster. Unknown or empty values never trip it: creates
-// (no assigned cluster yet), interpolated values (unknown until apply), and
-// omitted attributes (the plan copies state) are all legitimate.
-func clusterChangeForbidden(state, plan types.String) bool {
-	if state.IsNull() || state.IsUnknown() || state.ValueString() == "" {
-		return false
-	}
-	if plan.IsNull() || plan.IsUnknown() || plan.ValueString() == "" {
-		return false
-	}
-	return plan.ValueString() != state.ValueString()
-}
-
-// ModifyPlan rejects changes to an already-assigned cluster at plan time. The
-// server pins the cluster forever (there is no settings delete), so neither
-// an in-place update nor a replace can ever satisfy such a plan — failing
-// early beats a half-executed apply.
-func (r *AgentNetworkSettings) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Nothing to guard on destroy (null plan) or create (null state — the
-	// bootstrap path may pin any cluster).
-	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
-		return
-	}
-
-	var stateCluster, planCluster types.String
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("cluster"), &stateCluster)...)
-	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("cluster"), &planCluster)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if clusterChangeForbidden(stateCluster, planCluster) {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("cluster"),
-			"Cluster is immutable once assigned",
-			fmt.Sprintf("The account's Agent Network cluster is pinned to %q and cannot be changed or replaced — "+
-				"the settings row cannot be deleted or re-created on another cluster. Remove `cluster` from the "+
-				"configuration or set it back to the assigned value.", stateCluster.ValueString()),
-		)
-	}
-}
-
 func (r *AgentNetworkSettings) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
@@ -160,9 +141,9 @@ func (r *AgentNetworkSettings) Configure(_ context.Context, req resource.Configu
 }
 
 func agentNetworkSettingsAPIToTerraform(s *api.AgentNetworkSettings, data *AgentNetworkSettingsModel) {
-	data.Cluster = types.StringValue(s.Cluster)
-	data.Subdomain = types.StringValue(s.Subdomain)
 	data.Endpoint = types.StringValue(s.Endpoint)
+	data.ProxyAddress = types.StringValue(s.ProxyAddress)
+	data.Dedicated = types.BoolValue(s.Dedicated)
 	data.EnableLogCollection = types.BoolValue(s.EnableLogCollection)
 	data.EnablePromptCollection = types.BoolValue(s.EnablePromptCollection)
 	data.RedactPii = types.BoolValue(s.RedactPii)
@@ -173,20 +154,30 @@ func agentNetworkSettingsAPIToTerraform(s *api.AgentNetworkSettings, data *Agent
 	}
 }
 
+// configured reports whether the configuration set a string attribute to a
+// usable value, as opposed to omitting it or leaving it to be interpolated.
+func configured(v types.String) bool {
+	return !v.IsNull() && !v.IsUnknown() && v.ValueString() != ""
+}
+
 // settingsUpdateRequest builds an UpdateSettings request that starts from the
 // current server-side values and overrides only the fields the plan explicitly
 // set. The server replaces every mutable field on PUT, so without this merge an
 // omitted attribute would reset the account's value (turning off log/prompt
 // collection, or dropping access-log retention) instead of leaving it alone.
+//
+// The endpoint and proxy address are echoed from what the server holds: the PUT
+// requires them and rejects anything other than the assigned values.
 func settingsUpdateRequest(data *AgentNetworkSettingsModel, current *api.AgentNetworkSettings) api.AgentNetworkSettingsRequest {
 	req := api.AgentNetworkSettingsRequest{
+		Endpoint:               current.Endpoint,
+		ProxyAddress:           current.ProxyAddress,
 		EnableLogCollection:    current.EnableLogCollection,
 		EnablePromptCollection: current.EnablePromptCollection,
 		RedactPii:              current.RedactPii,
 	}
 	if current.AccessLogRetentionDays != nil {
-		v := *current.AccessLogRetentionDays
-		req.AccessLogRetentionDays = &v
+		req.AccessLogRetentionDays = *current.AccessLogRetentionDays
 	}
 
 	if !data.EnableLogCollection.IsNull() && !data.EnableLogCollection.IsUnknown() {
@@ -199,58 +190,94 @@ func settingsUpdateRequest(data *AgentNetworkSettingsModel, current *api.AgentNe
 		req.RedactPii = data.RedactPii.ValueBool()
 	}
 	if !data.AccessLogRetentionDays.IsNull() && !data.AccessLogRetentionDays.IsUnknown() {
+		req.AccessLogRetentionDays = int(data.AccessLogRetentionDays.ValueInt64())
+	}
+	return req
+}
+
+// settingsCreateRequest builds the bootstrap request. Only the collection fields
+// the configuration set are sent, so the server applies its own defaults to the
+// rest rather than this resource inventing them.
+func settingsCreateRequest(data *AgentNetworkSettingsModel) api.AgentNetworkSettingsCreateRequest {
+	req := api.AgentNetworkSettingsCreateRequest{}
+	if configured(data.Endpoint) {
+		req.Endpoint = data.Endpoint.ValueStringPointer()
+	}
+	if configured(data.ProxyAddress) {
+		req.ProxyAddress = data.ProxyAddress.ValueStringPointer()
+	}
+	if !data.EnableLogCollection.IsNull() && !data.EnableLogCollection.IsUnknown() {
+		req.EnableLogCollection = data.EnableLogCollection.ValueBoolPointer()
+	}
+	if !data.EnablePromptCollection.IsNull() && !data.EnablePromptCollection.IsUnknown() {
+		req.EnablePromptCollection = data.EnablePromptCollection.ValueBoolPointer()
+	}
+	if !data.RedactPii.IsNull() && !data.RedactPii.IsUnknown() {
+		req.RedactPii = data.RedactPii.ValueBoolPointer()
+	}
+	if !data.AccessLogRetentionDays.IsNull() && !data.AccessLogRetentionDays.IsUnknown() {
 		v := int(data.AccessLogRetentionDays.ValueInt64())
 		req.AccessLogRetentionDays = &v
 	}
 	return req
 }
 
-// applySettings reads the current server-managed singleton, merges the planned
-// overrides onto it, and PUTs the result. When the account has no settings
-// row yet, a configured cluster bootstraps it in the same call.
+// applySettings bootstraps the account when it has no gateway yet, and otherwise
+// updates the settings it already has.
+//
+// An empty endpoint on the read is the server's not-bootstrapped signal. In that
+// state only the create endpoint works — the update refuses with not-found — so
+// the two are not interchangeable.
 func (r *AgentNetworkSettings) applySettings(ctx context.Context, data *AgentNetworkSettingsModel, diags *diag.Diagnostics) {
 	current, err := r.client.GetSettings(ctx)
-	if err != nil {
-		if !netbird.IsNotFound(err) {
-			diags.AddError("Error reading Agent Network Settings", err.Error())
+	switch {
+	case err == nil && current.Endpoint != "":
+		if configured(data.Endpoint) && data.Endpoint.ValueString() != current.Endpoint {
+			diags.AddAttributeError(path.Root("endpoint"), "Endpoint is immutable once assigned",
+				fmt.Sprintf("The account's gateway endpoint is %q. Changing it means releasing that endpoint and "+
+					"allocating a new one, which this resource does by replacement; the account's Agent Network "+
+					"providers have to be destroyed first.", current.Endpoint))
 			return
 		}
-		// Management servers predating the defaults response answer the
-		// unbootstrapped state with a null body (translated to not-found by
-		// the client); fall back to the same defaults those servers apply at
-		// bootstrap so the merge below has a base either way.
-		retention := 30
-		current = &api.AgentNetworkSettings{EnableLogCollection: true, AccessLogRetentionDays: &retention}
-	}
+		if configured(data.ProxyAddress) && data.ProxyAddress.ValueString() != current.ProxyAddress {
+			diags.AddAttributeError(path.Root("proxy_address"), "Proxy address is immutable once assigned",
+				fmt.Sprintf("The account's gateway is served from %q. Changing it means releasing the endpoint and "+
+					"allocating a new one, which this resource does by replacement; the account's Agent Network "+
+					"providers have to be destroyed first.", current.ProxyAddress))
+			return
+		}
 
-	apiReq := settingsUpdateRequest(data, current)
+		updated, err := r.client.UpdateSettings(ctx, settingsUpdateRequest(data, current))
+		if err != nil {
+			diags.AddError("Error applying Agent Network Settings", err.Error())
+			return
+		}
+		agentNetworkSettingsAPIToTerraform(updated, data)
 
-	clusterConfigured := !data.Cluster.IsNull() && !data.Cluster.IsUnknown() && data.Cluster.ValueString() != ""
-	if clusterConfigured {
-		apiReq.Cluster = data.Cluster.ValueStringPointer()
-	}
-	// An empty endpoint is the server's not-bootstrapped signal.
-	if current.Endpoint == "" && !clusterConfigured {
-		diags.AddError(
-			"Agent Network not bootstrapped",
-			"The account has no Agent Network settings row yet. Set `cluster` on this resource to bootstrap it — "+
-				"the `netbird_reverse_proxy_clusters` data source lists valid cluster addresses — or create an "+
-				"Agent Network provider with `bootstrap_cluster` set and re-apply.",
-		)
-		return
-	}
+	case err == nil || netbird.IsNotFound(err):
+		// Not bootstrapped: exactly one of the two addresses picks the shape.
+		if configured(data.Endpoint) == configured(data.ProxyAddress) {
+			diags.AddError(
+				"Agent Network not bootstrapped",
+				"The account has no Agent Network gateway yet. Set exactly one of `proxy_address`, to allocate an "+
+					"endpoint beneath a shared proxy cluster, or `endpoint`, to claim a hostname served by a proxy "+
+					"dedicated to this account. The `netbird_reverse_proxy_clusters` data source lists cluster addresses.",
+			)
+			return
+		}
 
-	s, err := r.client.UpdateSettings(ctx, apiReq)
-	if err != nil {
-		diags.AddError("Error applying Agent Network Settings", err.Error())
-		return
-	}
+		created, err := r.client.CreateSettings(ctx, settingsCreateRequest(data))
+		if err != nil {
+			diags.AddError("Error bootstrapping Agent Network Settings", err.Error())
+			return
+		}
+		agentNetworkSettingsAPIToTerraform(created, data)
 
-	agentNetworkSettingsAPIToTerraform(s, data)
+	default:
+		diags.AddError("Error reading Agent Network Settings", err.Error())
+	}
 }
 
-// Create adopts the server-managed settings singleton, overriding only the
-// fields the configuration sets (singleton — no actual create).
 func (r *AgentNetworkSettings) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data AgentNetworkSettingsModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -281,8 +308,8 @@ func (r *AgentNetworkSettings) Read(ctx context.Context, req resource.ReadReques
 		resp.Diagnostics.AddError("Error reading Agent Network Settings", err.Error())
 		return
 	}
-	// An empty endpoint is the server's not-bootstrapped signal: the row this
-	// resource manages does not exist (yet), so drop it from state.
+	// An empty endpoint is the server's not-bootstrapped signal: the gateway this
+	// resource manages does not exist (any more), so drop it from state.
 	if s.Endpoint == "" {
 		resp.State.RemoveResource(ctx)
 		return
@@ -307,6 +334,15 @@ func (r *AgentNetworkSettings) Update(ctx context.Context, req resource.UpdateRe
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-// Delete is a no-op — the settings row always exists, we just stop managing it.
-func (r *AgentNetworkSettings) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
+// Delete releases the account's gateway, which is what makes a change of
+// endpoint or proxy address expressible as a replacement.
+//
+// The server guards the release: it refuses while the account still has Agent
+// Network providers, and while a proxy is actively serving a dedicated endpoint.
+// Those refusals are surfaced as they are — a gateway that is still in use is
+// not something to delete quietly. An already-released gateway is not an error.
+func (r *AgentNetworkSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	if err := r.client.DeleteSettings(ctx); err != nil && !netbird.IsNotFound(err) {
+		resp.Diagnostics.AddError("Error deleting Agent Network Settings", err.Error())
+	}
 }

--- a/internal/provider/agent_network_settings_resource.go
+++ b/internal/provider/agent_network_settings_resource.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -71,13 +72,10 @@ func (r *AgentNetworkSettings) Schema(_ context.Context, _ resource.SchemaReques
 					"providers to be destroyed first.",
 				Optional:   true,
 				Computed:   true,
-				Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
+				Validators: addressValidators("proxy_address"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-					// Only a configured change forces a replacement: once the
-					// server has assigned an endpoint, state carries it and a
-					// configuration that omits it must keep it.
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					requiresReplaceIfAddressChanged(),
 				},
 			},
 			"proxy_address": schema.StringAttribute{
@@ -87,10 +85,10 @@ func (r *AgentNetworkSettings) Schema(_ context.Context, _ resource.SchemaReques
 					"Immutable once assigned, with the same replacement semantics as `endpoint`.",
 				Optional:   true,
 				Computed:   true,
-				Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
+				Validators: addressValidators("endpoint"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					requiresReplaceIfAddressChanged(),
 				},
 			},
 			"dedicated": schema.BoolAttribute{
@@ -125,6 +123,54 @@ func (r *AgentNetworkSettings) Schema(_ context.Context, _ resource.SchemaReques
 			},
 		},
 	}
+}
+
+// hostnamePattern is the shape the server stores an address in: lowercase
+// labels of letters, digits and inner hyphens, separated by single dots.
+var hostnamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$`)
+
+// addressValidators guards the two gateway addresses. conflictsWith names the
+// other one, since exactly one of them bootstraps a gateway.
+//
+// The pattern is not only about catching typos early. The server lowercases and
+// trims the address before storing it, and Terraform requires a configured value
+// to come back from apply unchanged, so `Example.COM ` would be planned as
+// written and stored normalized — an inconsistent-result error naming the
+// provider as buggy. Refusing it at plan time says what is actually wrong.
+func addressValidators(conflictsWith string) []validator.String {
+	return []validator.String{
+		stringvalidator.LengthAtLeast(1),
+		stringvalidator.RegexMatches(hostnamePattern,
+			"must be a lowercase hostname: letters, digits and inner hyphens in each label, "+
+				"single dots between labels, and no surrounding whitespace"),
+		stringvalidator.ConflictsWith(path.MatchRoot(conflictsWith)),
+	}
+}
+
+// requiresReplaceIfAddressChanged replaces the resource when the configuration
+// moves an address the server has already assigned: the endpoint is released and
+// a new one allocated, which is the only way to express that change.
+//
+// Only a value the configuration actually states counts. Once assigned, state
+// carries the address, so a configuration that omits it must keep it — that much
+// stringplanmodifier.RequiresReplaceIfConfigured would also give. What it would
+// not give is the unknown case: an address interpolated from a value that is not
+// resolvable until apply (an attribute of a resource being replaced, say) reaches
+// this point unknown, which is neither null nor equal to state, so it would force
+// a replacement on every plan. Releasing the gateway allocates a new endpoint
+// under a shared cluster, so that would silently move the hostname agents call
+// while the address itself never changed.
+//
+// An unknown address is therefore left alone. applySettings is what catches the
+// case where it does resolve to a different value at apply time.
+func requiresReplaceIfAddressChanged() planmodifier.String {
+	return stringplanmodifier.RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+			resp.RequiresReplace = configured(req.ConfigValue)
+		},
+		"If the configured address changes, the endpoint is released and a new one allocated.",
+		"If the configured address changes, the endpoint is released and a new one allocated.",
+	)
 }
 
 func (r *AgentNetworkSettings) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/agent_network_settings_test.go
+++ b/internal/provider/agent_network_settings_test.go
@@ -14,19 +14,21 @@ func Test_agentNetworkSettingsAPIToTerraform(t *testing.T) {
 		expected AgentNetworkSettingsModel
 	}{
 		{
+			// A gateway beneath a shared cluster: the endpoint hangs one label
+			// below the proxy address, so the two differ and it is not dedicated.
 			resource: &api.AgentNetworkSettings{
-				Cluster:                "c1",
-				Subdomain:              "sub",
 				Endpoint:               "sub.c1",
+				ProxyAddress:           "c1",
+				Dedicated:              false,
 				EnableLogCollection:    true,
 				EnablePromptCollection: true,
 				RedactPii:              true,
 				AccessLogRetentionDays: valPtr(90),
 			},
 			expected: AgentNetworkSettingsModel{
-				Cluster:                types.StringValue("c1"),
-				Subdomain:              types.StringValue("sub"),
 				Endpoint:               types.StringValue("sub.c1"),
+				ProxyAddress:           types.StringValue("c1"),
+				Dedicated:              types.BoolValue(false),
 				EnableLogCollection:    types.BoolValue(true),
 				EnablePromptCollection: types.BoolValue(true),
 				RedactPii:              types.BoolValue(true),
@@ -34,19 +36,21 @@ func Test_agentNetworkSettingsAPIToTerraform(t *testing.T) {
 			},
 		},
 		{
-			// Absent retention means "keep indefinitely" and maps to null.
+			// A claimed hostname: endpoint and proxy address coincide, and the
+			// gateway is dedicated.
 			resource: &api.AgentNetworkSettings{
-				Cluster:   "c1",
-				Subdomain: "sub",
-				Endpoint:  "sub.c1",
+				Endpoint:     "gw.example",
+				ProxyAddress: "gw.example",
+				Dedicated:    true,
 			},
 			expected: AgentNetworkSettingsModel{
-				Cluster:                types.StringValue("c1"),
-				Subdomain:              types.StringValue("sub"),
-				Endpoint:               types.StringValue("sub.c1"),
+				Endpoint:               types.StringValue("gw.example"),
+				ProxyAddress:           types.StringValue("gw.example"),
+				Dedicated:              types.BoolValue(true),
 				EnableLogCollection:    types.BoolValue(false),
 				EnablePromptCollection: types.BoolValue(false),
 				RedactPii:              types.BoolValue(false),
+				// Absent retention means "keep indefinitely" and maps to null.
 				AccessLogRetentionDays: types.Int64Null(),
 			},
 		},
@@ -65,9 +69,12 @@ func Test_agentNetworkSettingsAPIToTerraform(t *testing.T) {
 // The settings row is a server-managed singleton and the API replaces every
 // mutable field on PUT. Fields the configuration does not set must therefore
 // adopt the account's current value; sending schema defaults instead would
-// silently disable log/prompt collection or drop access-log retention.
+// silently disable log/prompt collection or drop access-log retention. The two
+// addresses are echoed unchanged, because the API rejects any other value.
 func Test_settingsUpdateRequest(t *testing.T) {
 	current := &api.AgentNetworkSettings{
+		Endpoint:               "sub.c1",
+		ProxyAddress:           "c1",
 		EnableLogCollection:    true,
 		EnablePromptCollection: true,
 		RedactPii:              true,
@@ -88,10 +95,12 @@ func Test_settingsUpdateRequest(t *testing.T) {
 				AccessLogRetentionDays: types.Int64Null(),
 			},
 			expected: api.AgentNetworkSettingsRequest{
+				Endpoint:               "sub.c1",
+				ProxyAddress:           "c1",
 				EnableLogCollection:    true,
 				EnablePromptCollection: true,
 				RedactPii:              true,
-				AccessLogRetentionDays: valPtr(90),
+				AccessLogRetentionDays: 90,
 			},
 		},
 		{
@@ -103,10 +112,12 @@ func Test_settingsUpdateRequest(t *testing.T) {
 				AccessLogRetentionDays: types.Int64Value(30),
 			},
 			expected: api.AgentNetworkSettingsRequest{
+				Endpoint:               "sub.c1",
+				ProxyAddress:           "c1",
 				EnableLogCollection:    false,
 				EnablePromptCollection: false,
 				RedactPii:              false,
-				AccessLogRetentionDays: valPtr(30),
+				AccessLogRetentionDays: 30,
 			},
 		},
 		{
@@ -118,10 +129,29 @@ func Test_settingsUpdateRequest(t *testing.T) {
 				AccessLogRetentionDays: types.Int64Null(),
 			},
 			expected: api.AgentNetworkSettingsRequest{
+				Endpoint:               "sub.c1",
+				ProxyAddress:           "c1",
 				EnableLogCollection:    true,
 				EnablePromptCollection: true,
 				RedactPii:              false,
-				AccessLogRetentionDays: valPtr(90),
+				AccessLogRetentionDays: 90,
+			},
+		},
+		{
+			// A configured address is never sent as such: the assigned value is,
+			// so a stale configuration cannot turn into a rejected request.
+			name: "configured addresses do not override the assigned ones",
+			data: AgentNetworkSettingsModel{
+				Endpoint:     types.StringValue("other.example"),
+				ProxyAddress: types.StringValue("other"),
+			},
+			expected: api.AgentNetworkSettingsRequest{
+				Endpoint:               "sub.c1",
+				ProxyAddress:           "c1",
+				EnableLogCollection:    true,
+				EnablePromptCollection: true,
+				RedactPii:              true,
+				AccessLogRetentionDays: 90,
 			},
 		},
 	}
@@ -136,27 +166,85 @@ func Test_settingsUpdateRequest(t *testing.T) {
 	}
 }
 
-// Test_clusterChangeForbidden pins the plan-time immutability gate: only a
-// known, non-empty planned cluster that differs from a known, non-empty
-// assigned one is rejected. Creates, interpolated (unknown) values, and
-// omitted attributes must all pass — the server remains the backstop there.
-func Test_clusterChangeForbidden(t *testing.T) {
+// Bootstrap sends only what the configuration set, so the server applies its own
+// defaults to the rest rather than this provider inventing them. Exactly one of
+// the two addresses travels, which is what selects the gateway's shape.
+func Test_settingsCreateRequest(t *testing.T) {
 	cases := []struct {
-		name      string
-		state     types.String
-		plan      types.String
-		forbidden bool
+		name     string
+		data     AgentNetworkSettingsModel
+		expected api.AgentNetworkSettingsCreateRequest
 	}{
-		{"create: null state", types.StringNull(), types.StringValue("eu.proxy"), false},
-		{"create: empty state", types.StringValue(""), types.StringValue("eu.proxy"), false},
-		{"omitted: plan copies state", types.StringValue("eu.proxy"), types.StringValue("eu.proxy"), false},
-		{"interpolated: unknown plan", types.StringValue("eu.proxy"), types.StringUnknown(), false},
-		{"null plan", types.StringValue("eu.proxy"), types.StringNull(), false},
-		{"change is forbidden", types.StringValue("eu.proxy"), types.StringValue("us.proxy"), true},
+		{
+			name: "proxy address only, no collection fields",
+			data: AgentNetworkSettingsModel{
+				ProxyAddress:           types.StringValue("c1"),
+				Endpoint:               types.StringNull(),
+				EnableLogCollection:    types.BoolNull(),
+				EnablePromptCollection: types.BoolUnknown(),
+				RedactPii:              types.BoolNull(),
+				AccessLogRetentionDays: types.Int64Null(),
+			},
+			expected: api.AgentNetworkSettingsCreateRequest{
+				ProxyAddress: valPtr("c1"),
+			},
+		},
+		{
+			name: "endpoint claim with collection fields",
+			data: AgentNetworkSettingsModel{
+				Endpoint:               types.StringValue("gw.example"),
+				ProxyAddress:           types.StringUnknown(),
+				EnableLogCollection:    types.BoolValue(true),
+				EnablePromptCollection: types.BoolValue(false),
+				RedactPii:              types.BoolValue(true),
+				AccessLogRetentionDays: types.Int64Value(45),
+			},
+			expected: api.AgentNetworkSettingsCreateRequest{
+				Endpoint:               valPtr("gw.example"),
+				EnableLogCollection:    valPtr(true),
+				EnablePromptCollection: valPtr(false),
+				RedactPii:              valPtr(true),
+				AccessLogRetentionDays: valPtr(45),
+			},
+		},
+		{
+			// An empty string is an omitted address, not a claim on "".
+			name: "empty addresses are omitted",
+			data: AgentNetworkSettingsModel{
+				Endpoint:     types.StringValue(""),
+				ProxyAddress: types.StringValue(""),
+			},
+			expected: api.AgentNetworkSettingsCreateRequest{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := settingsCreateRequest(&c.data)
+			if !reflect.DeepEqual(out, c.expected) {
+				t.Fatalf("Expected:\n%#v\nFound:\n%#v", c.expected, out)
+			}
+		})
+	}
+}
+
+// configured is what decides whether an address travels in a bootstrap request,
+// so the states that must not count as configured are pinned here: an omitted
+// attribute, one that is interpolated and still unknown, and an empty string.
+func Test_configured(t *testing.T) {
+	cases := []struct {
+		name  string
+		value types.String
+		want  bool
+	}{
+		{"null", types.StringNull(), false},
+		{"unknown", types.StringUnknown(), false},
+		{"empty", types.StringValue(""), false},
+		{"set", types.StringValue("c1"), true},
 	}
 	for _, c := range cases {
-		if got := clusterChangeForbidden(c.state, c.plan); got != c.forbidden {
-			t.Errorf("%s: clusterChangeForbidden = %v, want %v", c.name, got, c.forbidden)
+		if got := configured(c.value); got != c.want {
+			t.Errorf("%s: configured = %v, want %v", c.name, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Why

Management replaced the account's cluster-plus-subdomain model with a gateway addressed directly. Against the netbird revision this bumps to, the current provider does not compile and the old bootstrap path is gone from the API:

| Old | New |
|---|---|
| `cluster` + generated `subdomain`, `endpoint = <subdomain>.<cluster>` | `endpoint` and `proxy_address` name the gateway; `dedicated` says whether they coincide |
| bootstrap by `PUT /settings` with `cluster`, or by a provider create with `bootstrap_cluster` | bootstrap by `POST /settings` with exactly one of `proxy_address` or `endpoint` |
| cluster pinned forever, no way to release | both addresses immutable, `DELETE /settings` releases them |
| `access_log_retention_days` optional in the update body | required |

The API surface diff is confined to this: `BootstrapCluster`, `Cluster` and `Subdomain` removed, `Dedicated`, `ProxyAddress` and `AgentNetworkSettingsCreateRequest` added. Nothing else the provider touches changed.

## What

`go.mod` moves to `v0.76.4-0.20260810175000-27b2d3f35159`.

**`netbird_agent_network_settings`** takes the new model. Set exactly one address to bootstrap an account that has no gateway: `proxy_address` allocates an endpoint one label beneath a shared cluster, `endpoint` claims a hostname served by a proxy dedicated to the account. Both are `Optional` + `Computed`, so they carry the assigned value afterwards, and both use `RequiresReplaceIfConfigured` — a configured change forces a replacement, which the new delete makes expressible, while a configuration that omits them keeps what the server assigned. `dedicated` is exposed read-only. Update echoes both addresses back, since the `PUT` requires them and rejects any other value.

**Delete now releases the gateway** instead of doing nothing. The server guards it — refused while providers still route through the gateway, or while a proxy still serves a dedicated endpoint — and those refusals surface rather than being swallowed: a gateway still in use is not something to drop quietly.

**`netbird_agent_network_provider`** loses `bootstrap_cluster` (resource and data source), and its unbootstrapped-account warning now points at the settings resource, the only thing that bootstraps.

**The dependency between the two resources inverts.** The gateway must exist before the providers that route through it and outlive them, so the example and the acceptance tests have the provider depend on the settings. Getting this backwards is what a destroy fails on, so it is worth stating plainly.

## Testing

Acceptance tests run against a `netbird-server` container built from the pinned revision. All 12 agent-network tests pass, including three new ones: bootstrap via `proxy_address` (asserting the endpoint really is one label beneath it), bootstrap by claiming an `endpoint` (asserting `proxy_address` equals it and `dedicated` is true), and a bootstrap with neither address, which has to be reported rather than sent to an API that would refuse it. New unit tests cover the create-request builder and the address-configured predicate; the update-request test gains a case pinning that a stale configured address never overrides the assigned one.

Because releasing a gateway is now possible, the bootstrap tests reset the account in `PreCheck` and run whatever ran before them, instead of only when scheduled first.

The rest of the suite still depends on the seeded fixtures in `test/seed_database.sql`, so it was not run against this deployment — those fixtures are what #192 replaces.

## Note

This also resolves what #192's remaining red check was reporting. On the previously pinned revision, `PUT /api/agent-network/settings` with `cluster` on an account with no settings row deadlocked: the bootstrap branch validated permissions through a second store query from inside the store transaction, and with the sqlite store the pool is capped at one connection, so it waited out the five-minute transaction timeout and returned a 500. That path no longer exists — the `PUT` answers instantly with a 404 pointing at the `POST`, and the `POST` bootstraps in milliseconds.


---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agent Network settings now support bootstrapping with either a proxy address or a dedicated endpoint.
  - Added gateway endpoint output and proxy-cluster selection examples.
  - Gateway identity is preserved during updates and released when settings are deleted.

- **Changes**
  - Removed provider bootstrap-cluster configuration and related documentation.
  - Address inputs are mutually exclusive, normalized, and require replacement when changed.
  - Providers now warn when Agent Network settings do not provide an endpoint.

- **Tests**
  - Added coverage for proxy, dedicated endpoint, validation, updates, and gateway lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->