### PR TITLE
[tests] Cover the lifecycle operations the suite never tested

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.8
 
 require (
 	github.com/hashicorp/go-version v1.9.0
+	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
@@ -53,7 +54,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.1 // indirect
-	github.com/hashicorp/terraform-json v0.27.2 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect

--- a/internal/provider/account_settings_acc_test.go
+++ b/internal/provider/account_settings_acc_test.go
@@ -61,6 +61,11 @@ func Test_Account_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/agent_network_acc_test.go
+++ b/internal/provider/agent_network_acc_test.go
@@ -124,15 +124,18 @@ func Test_AgentNetworkProvider_Create(t *testing.T) {
 	testE2E(t)
 	rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_agent_network_provider." + rName
+	var createdID string
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testAgentNetworkClient().GetProvider, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testAgentNetworkProviderResource(rName, rName, `{ "x-portkey-config" = "pc-acc" }`, "true"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "provider_id", "openai_api"),
 					resource.TestCheckResourceAttr(rNameFull, "metadata_disabled", "true"),
@@ -163,6 +166,7 @@ func Test_AgentNetworkProvider_UpdatePreservesExtraValues(t *testing.T) {
 	testE2E(t)
 	rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_agent_network_provider." + rName
+	var createdID string
 
 	checkPersisted := func(s *terraform.State) error {
 		p, err := testGetProvider(s.RootModule().Resources[rNameFull].Primary.Attributes["id"])
@@ -181,6 +185,7 @@ func Test_AgentNetworkProvider_UpdatePreservesExtraValues(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testAgentNetworkClient().GetProvider, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
@@ -192,6 +197,7 @@ func Test_AgentNetworkProvider_UpdatePreservesExtraValues(t *testing.T) {
 				ResourceName: rName,
 				Config:       testAgentNetworkProviderResource(rName, rName+"-renamed", `{ "x-portkey-config" = "pc-acc" }`, "true"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName+"-renamed"),
 					checkPersisted,
 				),
@@ -207,6 +213,7 @@ func Test_AgentNetworkProvider_ProviderIdUpdatesInPlace(t *testing.T) {
 	testE2E(t)
 	rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_agent_network_provider." + rName
+	var createdID string
 
 	config := func(providerID, upstream string) string {
 		return fmt.Sprintf(`resource "netbird_agent_network_provider" "%s" {
@@ -221,6 +228,7 @@ func Test_AgentNetworkProvider_ProviderIdUpdatesInPlace(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testAgentNetworkClient().GetProvider, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
@@ -234,6 +242,7 @@ func Test_AgentNetworkProvider_ProviderIdUpdatesInPlace(t *testing.T) {
 				ResourceName: rName,
 				Config:       config("anthropic_api", "https://api.anthropic.com"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttr(rNameFull, "provider_id", "anthropic_api"),
 					func(s *terraform.State) error {
 						if got := s.RootModule().Resources[rNameFull].Primary.Attributes["id"]; got != firstID {
@@ -251,6 +260,7 @@ func Test_AgentNetworkGuardrail_Create(t *testing.T) {
 	testE2E(t)
 	rName := "ang" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_agent_network_guardrail." + rName
+	var createdID string
 
 	config := func(models string, redactPii string) string {
 		return fmt.Sprintf(`resource "netbird_agent_network_guardrail" "%s" {
@@ -270,11 +280,13 @@ func Test_AgentNetworkGuardrail_Create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testAgentNetworkClient().GetGuardrail, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       config(`["gpt-4.1"]`, "true"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "model_allowlist.models.#", "1"),
 					resource.TestCheckResourceAttr(rNameFull, "prompt_capture.redact_pii", "true"),
@@ -296,6 +308,7 @@ func Test_AgentNetworkPolicy_Create(t *testing.T) {
 	testE2E(t)
 	rName := "anpol" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_agent_network_policy." + rName
+	var createdID string
 
 	config := fmt.Sprintf(`
 resource "netbird_group" "%[1]s" {
@@ -336,11 +349,13 @@ resource "netbird_agent_network_policy" "%[1]s" {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testAgentNetworkClient().GetPolicy, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       config,
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "source_groups.#", "1"),
 					resource.TestCheckResourceAttr(rNameFull, "destination_provider_ids.#", "1"),

--- a/internal/provider/agent_network_acc_test.go
+++ b/internal/provider/agent_network_acc_test.go
@@ -155,6 +155,12 @@ func Test_AgentNetworkProvider_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:            rNameFull,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"api_key"},
+			},
 		},
 	})
 }
@@ -300,6 +306,11 @@ func Test_AgentNetworkGuardrail_Create(t *testing.T) {
 					resource.TestCheckResourceAttr(rNameFull, "prompt_capture.redact_pii", "false"),
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -365,6 +376,11 @@ resource "netbird_agent_network_policy" "%[1]s" {
 					// Not set in config, so it takes the schema default.
 					resource.TestCheckResourceAttr(rNameFull, "token_limit.user_cap", "0"),
 				),
+			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/data_source_acc_test.go
+++ b/internal/provider/data_source_acc_test.go
@@ -127,17 +127,19 @@ func Test_User_DataSource(t *testing.T) {
 func Test_IdentityProvider_DataSource(t *testing.T) {
 	testE2E(t)
 	rName := "idp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	// "google" rather than the "oidc" the resource tests use: the type validator
-	// accepts seven values and only one was ever exercised.
-	//
 	// The issuer has to be a real one. The provider fetches
 	// <issuer>/.well-known/openid-configuration before accepting the resource, so
 	// an invented hostname fails with "identity provider issuer is unreachable"
 	// rather than testing anything. That also means this resource cannot be
 	// covered on a runner without egress — the pre-existing tests only pass
 	// because their JumpCloud issuer resolves.
-	cfg := testIdentityProviderResource(rName, "jumpcloud", "google", "client-id", "client-secret",
-		"https://accounts.google.com")
+	//
+	// The type stays "oidc" because the two OAuth2 types, google and microsoft,
+	// do not survive a read: the management server stores those connectors
+	// without the issuer, so it comes back empty and the data source can only
+	// report what the API tells it.
+	cfg := testIdentityProviderResource(rName, "jumpcloud", "oidc", "client-id", "client-secret",
+		"https://oauth.id.jumpcloud.com/")
 	// client_secret is write-only, so it is not comparable.
 	dsCase(t, cfg+dataSourceByID("identity_provider", rName),
 		samePair("identity_provider", rName, "name", "type", "client_id", "issuer"))

--- a/internal/provider/data_source_acc_test.go
+++ b/internal/provider/data_source_acc_test.go
@@ -1,0 +1,239 @@
+//go:build e2e
+
+// Data source coverage.
+//
+// 19 of the provider's 25 data sources had no acceptance test. A data source is
+// a read path with its own schema and its own mapping code, so an untested one
+// can return the wrong field, drop an optional one, or diverge from the resource
+// that produced the object, and nothing would say so.
+//
+// Each test here creates a resource and then reads it back through the matching
+// data source in the same configuration, so the data source is exercised against
+// an object whose values the test already knows. The central assertion is
+// TestCheckResourceAttrPair: the data source and the resource must agree
+// attribute by attribute. That is stronger than asserting literals, because it
+// also fails when both sides are wrong in different ways, and it does not have
+// to be updated when a fixture value changes.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// dataSourceByID reads back the resource the same configuration just created,
+// addressed by its server-assigned ID. Referencing the resource's attribute is
+// what orders the two: Terraform will not read the data source until the
+// resource exists.
+func dataSourceByID(kind, rName string) string {
+	return fmt.Sprintf(`
+data "netbird_%[1]s" "%[2]s" {
+  id = netbird_%[1]s.%[2]s.id
+}
+`, kind, rName)
+}
+
+// samePair asserts the data source agrees with the resource on each attribute.
+func samePair(kind, rName string, attrs ...string) resource.TestCheckFunc {
+	ds := "data.netbird_" + kind + "." + rName
+	res := "netbird_" + kind + "." + rName
+	checks := []resource.TestCheckFunc{resource.TestCheckResourceAttrSet(ds, "id")}
+	for _, a := range attrs {
+		checks = append(checks, resource.TestCheckResourceAttrPair(ds, a, res, a))
+	}
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+// dsCase runs one create-then-read-back case.
+func dsCase(t *testing.T, config string, check resource.TestCheckFunc) {
+	t.Helper()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps:                    []resource.TestStep{{Config: config, Check: check}},
+	})
+}
+
+func Test_Group_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	dsCase(t, testGroupResource(rName, `[]`)+dataSourceByID("group", rName),
+		samePair("group", rName, "name", "peers.#"))
+}
+
+func Test_Network_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "n" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	dsCase(t, testNetworkResource(rName, `Test`)+dataSourceByID("network", rName),
+		samePair("network", rName, "name", "description"))
+}
+
+func Test_NameserverGroup_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "ns" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testNameserverGroupResource(rName, `1.1.1.1`, `53`, fmt.Sprintf("[%q]", e2eGroupAllID()))
+	dsCase(t, cfg+dataSourceByID("nameserver_group", rName),
+		samePair("nameserver_group", rName, "name", "enabled", "nameservers.#", "groups.#"))
+}
+
+func Test_Policy_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "p" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testPolicyResourceGroups(rName, rName, "desc", "accept", "udp", e2eGroupAllID(), e2eGroupNotAllID(), "443")
+	dsCase(t, cfg+dataSourceByID("policy", rName),
+		samePair("policy", rName, "name", "description", "enabled"))
+}
+
+func Test_PostureCheck_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "pc" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testPostureCheckResource(rName, `posture_check`, `0.40.0`, `15`, `10`, `12`, `6.8.0`, `2531`,
+		`EG`, `Cairo`, `allow`, `15.160.0.0/16`, `deny`, `/root`, `C:\\process.exe`, `/macpath`)
+	dsCase(t, cfg+dataSourceByID("posture_check", rName),
+		samePair("posture_check", rName, "name", "description"))
+}
+
+func Test_Route_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testRouteResource(rName, e2eGroupAllID(), `null`, `desc`, `null`, `["example.com"]`,
+		fmt.Sprintf("[%q]", e2eGroupNotAllID()), `null`)
+	dsCase(t, cfg+dataSourceByID("route", rName),
+		samePair("route", rName, "network_id", "description", "groups.#"))
+}
+
+func Test_SetupKey_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testSetupKeyResource(rName, `1800`, `reusable`, `false`, `[]`, `false`, `false`, `0`)
+	// Not the key itself: the server returns it only at creation, so the data
+	// source cannot know it and comparing the two would assert nothing useful.
+	dsCase(t, cfg+dataSourceByID("setup_key", rName),
+		samePair("setup_key", rName, "name", "type", "ephemeral", "revoked"))
+}
+
+func Test_User_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testUserResource(rName, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `false`, `user`)
+	dsCase(t, cfg+dataSourceByID("user", rName),
+		samePair("user", rName, "name", "role", "is_service_user", "is_blocked"))
+}
+
+func Test_IdentityProvider_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "idp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	// "okta" rather than the "oidc" the resource tests use: the type validator
+	// accepts seven values and only one of them was ever exercised.
+	cfg := testIdentityProviderResource(rName, "jumpcloud", "okta", "client-id", "client-secret",
+		"https://acc.okta.example/oauth2")
+	// client_secret is write-only, so it is not comparable.
+	dsCase(t, cfg+dataSourceByID("identity_provider", rName),
+		samePair("identity_provider", rName, "name", "type", "client_id", "issuer"))
+}
+
+func Test_DNSSettings_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "dns" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	// The settings are per-account rather than per-object, so the data source
+	// takes no selector and there is nothing to address it by.
+	cfg := testDNSSettingsResource(rName, "[]") + `
+data "netbird_dns_settings" "current" {}
+`
+	dsCase(t, cfg, resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttrPair("data.netbird_dns_settings.current",
+			"disabled_management_groups.#", "netbird_dns_settings."+rName, "disabled_management_groups.#"),
+	))
+}
+
+func Test_AccountSettings_DataSource(t *testing.T) {
+	env := testE2E(t)
+	// Also a per-account singleton, and one that exists without being created,
+	// so this reads the account the harness bootstrapped.
+	dsCase(t, `data "netbird_account_settings" "current" {}`,
+		resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("data.netbird_account_settings.current", "id", env.AccountID),
+			resource.TestCheckResourceAttrSet("data.netbird_account_settings.current", "peer_login_expiration"),
+		))
+}
+
+func Test_Peer_DataSource(t *testing.T) {
+	testE2E(t)
+	// A peer is registered by an agent rather than created by Terraform, so this
+	// reads one of the shared fixtures directly instead of creating anything.
+	peerID := testPeerID(t, "peer1")
+	dsCase(t, fmt.Sprintf(`
+data "netbird_peer" "p" {
+  id = %q
+}
+`, peerID), resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr("data.netbird_peer.p", "id", peerID),
+		resource.TestCheckResourceAttr("data.netbird_peer.p", "name", "peer1"),
+		resource.TestCheckResourceAttrSet("data.netbird_peer.p", "os"),
+		resource.TestCheckResourceAttrSet("data.netbird_peer.p", "ip"),
+	))
+}
+
+func Test_NetworkResource_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "nre" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testNetworkResourceResource(rName, e2eNetworkID(), `example.com`,
+		fmt.Sprintf("[%q, %q]", e2eGroupNotAllID(), e2eGroupAllID()), rName) + fmt.Sprintf(`
+data "netbird_network_resource" "%[1]s" {
+  network_id = %[2]q
+  id         = netbird_network_resource.%[1]s.id
+}
+`, rName, e2eNetworkID())
+	dsCase(t, cfg, samePair("network_resource", rName, "name", "address", "groups.#"))
+}
+
+func Test_NetworkRouter_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "nro" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testNetworkRouterResource(rName, e2eNetworkID(), fmt.Sprintf("[%q]", e2eGroupNotAllID())) +
+		fmt.Sprintf(`
+data "netbird_network_router" "%[1]s" {
+  network_id = %[2]q
+  id         = netbird_network_router.%[1]s.id
+}
+`, rName, e2eNetworkID())
+	dsCase(t, cfg, samePair("network_router", rName, "peer_groups.#", "masquerade", "metric"))
+}
+
+func Test_Token_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "t" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	userID := mustE2E().UserID
+	cfg := testTokenResource(rName, userID, `180`) + fmt.Sprintf(`
+data "netbird_token" "%[1]s" {
+  user_id = %[2]q
+  id      = netbird_token.%[1]s.id
+}
+`, rName, userID)
+	// The token value itself is returned only at creation, so it is not
+	// comparable against a read.
+	dsCase(t, cfg, samePair("token", rName, "name", "user_id"))
+}
+
+func Test_AgentNetworkProvider_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testAgentNetworkProviderResource(rName, rName, `{ "x-portkey-config" = "pc-ds" }`, "false")
+	// api_key is write-only.
+	dsCase(t, cfg+dataSourceByID("agent_network_provider", rName),
+		samePair("agent_network_provider", rName, "name", "enabled"))
+}
+
+func Test_Scim_DataSource(t *testing.T) {
+	// Skipped for the same reason as the SCIM resource tests: the integration is
+	// cloud-only, so a self-hosted deployment has nothing to read.
+	t.Skip("skipping cloud test")
+	rName := "scim" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testScimResource(rName, "azure", `"azure-scim"`, `null`, `["eng"]`, `["users"]`)
+	dsCase(t, cfg+dataSourceByID("scim", rName),
+		samePair("scim", rName, "provider_name", "enabled"))
+}

--- a/internal/provider/data_source_acc_test.go
+++ b/internal/provider/data_source_acc_test.go
@@ -127,10 +127,17 @@ func Test_User_DataSource(t *testing.T) {
 func Test_IdentityProvider_DataSource(t *testing.T) {
 	testE2E(t)
 	rName := "idp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	// "okta" rather than the "oidc" the resource tests use: the type validator
-	// accepts seven values and only one of them was ever exercised.
-	cfg := testIdentityProviderResource(rName, "jumpcloud", "okta", "client-id", "client-secret",
-		"https://acc.okta.example/oauth2")
+	// "google" rather than the "oidc" the resource tests use: the type validator
+	// accepts seven values and only one was ever exercised.
+	//
+	// The issuer has to be a real one. The provider fetches
+	// <issuer>/.well-known/openid-configuration before accepting the resource, so
+	// an invented hostname fails with "identity provider issuer is unreachable"
+	// rather than testing anything. That also means this resource cannot be
+	// covered on a runner without egress — the pre-existing tests only pass
+	// because their JumpCloud issuer resolves.
+	cfg := testIdentityProviderResource(rName, "jumpcloud", "google", "client-id", "client-secret",
+		"https://accounts.google.com")
 	// client_secret is write-only, so it is not comparable.
 	dsCase(t, cfg+dataSourceByID("identity_provider", rName),
 		samePair("identity_provider", rName, "name", "type", "client_id", "issuer"))

--- a/internal/provider/dns_record_acc_test.go
+++ b/internal/provider/dns_record_acc_test.go
@@ -16,13 +16,16 @@ func Test_DNSRecord_Create(t *testing.T) {
 	zoneName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_dns_record." + rName
+	var zoneID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().DNSZones.GetZone, &zoneID),
 		Steps: []resource.TestStep{
 			{
 				Config: testDNSRecordResource(zoneName, "test.local", rName, "www", "A", "192.168.1.1", 300),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordAttr(rNameFull, "zone_id", &zoneID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttrSet(rNameFull, "zone_id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", "www.test.local"),
@@ -46,13 +49,16 @@ func Test_DNSRecord_Update(t *testing.T) {
 	zoneName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_dns_record." + rName
+	var zoneID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().DNSZones.GetZone, &zoneID),
 		Steps: []resource.TestStep{
 			{
 				Config: testDNSRecordResource(zoneName, "test.local", rName, "www", "A", "192.168.1.1", 300),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordAttr(rNameFull, "zone_id", &zoneID),
 					resource.TestCheckResourceAttr(rNameFull, "name", "www.test.local"),
 					resource.TestCheckResourceAttr(rNameFull, "content", "192.168.1.1"),
 					resource.TestCheckResourceAttr(rNameFull, "ttl", "300"),
@@ -75,13 +81,16 @@ func Test_DNSRecord_CNAME(t *testing.T) {
 	zoneName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_dns_record." + rName
+	var zoneID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().DNSZones.GetZone, &zoneID),
 		Steps: []resource.TestStep{
 			{
 				Config: testDNSRecordResource(zoneName, "test.local", rName, "mail", "CNAME", "mail.example.com", 300),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordAttr(rNameFull, "zone_id", &zoneID),
 					resource.TestCheckResourceAttr(rNameFull, "name", "mail.test.local"),
 					resource.TestCheckResourceAttr(rNameFull, "type", "CNAME"),
 					resource.TestCheckResourceAttr(rNameFull, "content", "mail.example.com"),

--- a/internal/provider/dns_settings_acc_test.go
+++ b/internal/provider/dns_settings_acc_test.go
@@ -27,11 +27,6 @@ func Test_DNSSettings_Create(t *testing.T) {
 					resource.TestCheckResourceAttr(rNameFull, "disabled_management_groups.#", "0"),
 				),
 			},
-			{
-				ResourceName:      rNameFull,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }

--- a/internal/provider/dns_settings_acc_test.go
+++ b/internal/provider/dns_settings_acc_test.go
@@ -27,6 +27,11 @@ func Test_DNSSettings_Create(t *testing.T) {
 					resource.TestCheckResourceAttr(rNameFull, "disabled_management_groups.#", "0"),
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/dns_zone_acc_test.go
+++ b/internal/provider/dns_zone_acc_test.go
@@ -14,14 +14,17 @@ func Test_DNSZone_Create(t *testing.T) {
 	testE2E(t)
 	rName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_dns_zone." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().DNSZones.GetZone, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testDNSZoneResource(rName, "test.local", true, false, fmt.Sprintf("[%q]", e2eGroupAllID())),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					resource.TestCheckResourceAttr(rNameFull, "domain", "test.local"),
@@ -42,14 +45,17 @@ func Test_DNSZone_Update(t *testing.T) {
 	testE2E(t)
 	rName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_dns_zone." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().DNSZones.GetZone, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testDNSZoneResource(rName, "test.local", true, false, fmt.Sprintf("[%q]", e2eGroupAllID())),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					resource.TestCheckResourceAttr(rNameFull, "domain", "test.local"),

--- a/internal/provider/e2e_harness_test.go
+++ b/internal/provider/e2e_harness_test.go
@@ -73,11 +73,19 @@ const (
 
 // e2ePeerNames are the hostnames the agent containers register under, in the
 // order the tests expect to find them.
-// peer4 exists so the delete test has an agent it can consume. Deleting a peer
-// deregisters the device, so a test that asserts deletion cannot use one of the
-// peers the other tests address by name — it would remove a fixture they need,
-// and Go runs peer_acc_test.go before peers_acc_test.go.
-var e2ePeerNames = []string{"peer1", "peer2", "peer3", "peer4"}
+//
+// They are split by purpose, because a test that manages a peer through its own
+// lifecycle destroys it: peer1 and peer2 are shared and read-only, addressed by
+// name by the group, route, peers and reverse-proxy tests and expected to
+// survive the whole run, while peer3 to peer5 are consumable, one per lifecycle
+// test. One each rather than sharing, since sharing would make the later test
+// depend on the order Go compiles the files in.
+//
+// Deleting a peer does not actually deregister the device today — Peer.Delete
+// skips the API call under TF_ACC, which is what Test_Peer_Delete reports. The
+// split is what stops that from becoming a cascade of failures once the delete
+// works.
+var e2ePeerNames = []string{"peer1", "peer2", "peer3", "peer4", "peer5"}
 
 // e2eStack is the live deployment plus the IDs of the fixtures created on it.
 type e2eStack struct {
@@ -665,5 +673,29 @@ func testCheckAbsentFromList[T any](list func(context.Context) ([]T, error), id 
 			}
 		}
 		return nil
+	}
+}
+
+// testImportIDFrom builds a composite import ID out of attributes in state, for
+// the resources whose ImportState expects more than the object's own ID — a
+// network resource is addressed as network_id/id, a token as user_id/id.
+//
+// The separator is a parameter because the provider is not consistent about it:
+// dns_record splits on ":" while the others split on "/".
+func testImportIDFrom(resourceName, sep string, attrs ...string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("%s is not in state, so no import ID can be built", resourceName)
+		}
+		parts := make([]string, 0, len(attrs))
+		for _, a := range attrs {
+			v := rs.Primary.Attributes[a]
+			if v == "" {
+				return "", fmt.Errorf("%s has no %s in state", resourceName, a)
+			}
+			parts = append(parts, v)
+		}
+		return strings.Join(parts, sep), nil
 	}
 }

--- a/internal/provider/e2e_harness_test.go
+++ b/internal/provider/e2e_harness_test.go
@@ -699,3 +699,23 @@ func testImportIDFrom(resourceName, sep string, attrs ...string) resource.Import
 		return strings.Join(parts, sep), nil
 	}
 }
+
+// testIDChanged asserts the object was replaced rather than updated in place, by
+// comparing against the ID recorded in an earlier step. It is the assertion that
+// makes a RequiresReplace declaration mean something: without it a provider that
+// quietly updated in place would look identical to one that recreated.
+func testIDChanged(resourceName string, previous *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *previous == "" {
+			return errors.New("no earlier ID was recorded, so a replacement cannot be detected")
+		}
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("%s is not in state", resourceName)
+		}
+		if got := rs.Primary.Attributes["id"]; got == *previous {
+			return fmt.Errorf("%s kept id %s across a change the schema marks RequiresReplace, so it was updated in place instead of being recreated", resourceName, got)
+		}
+		return nil
+	}
+}

--- a/internal/provider/e2e_harness_test.go
+++ b/internal/provider/e2e_harness_test.go
@@ -50,6 +50,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/netbirdio/netbird/e2e/harness"
 	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
@@ -566,5 +568,58 @@ func Test_sameIDSet(t *testing.T) {
 				t.Errorf("sameIDSet(%v) = %v, want %v", tc.got, got, tc.want)
 			}
 		})
+	}
+}
+
+// Destroy coverage.
+//
+// The destroy half of a resource's lifecycle went almost entirely unchecked: 3
+// of 65 acceptance tests asserted anything about it, so a resource that failed
+// to delete server-side looked exactly like one that deleted cleanly. Terraform
+// removes the resource from state either way, and the next test creates its own
+// randomly named fixture, so nothing downstream notices the leak.
+//
+// Asking the server for the object by ID is stricter than listing objects and
+// matching a name. It catches a delete that removed the wrong object, and it
+// separates "the object is gone" from "the check could not tell" — a not-found
+// is the only answer that proves a delete, where any other error means the
+// check itself failed and must not be read as success.
+
+// testRecordID captures a resource's server-assigned ID from state while the
+// resource still exists. CheckDestroy runs once Terraform has forgotten the
+// resource, so the ID has to be taken during the test rather than after it.
+func testRecordID(resourceName string, into *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("%s is not in state, so its ID cannot be recorded for the destroy check", resourceName)
+		}
+		id := rs.Primary.Attributes["id"]
+		if id == "" {
+			return fmt.Errorf("%s has no id attribute in state", resourceName)
+		}
+		*into = id
+		return nil
+	}
+}
+
+// testCheckGone builds a CheckDestroy that requires the recorded object to be
+// absent from the management server. Pass the API's own getter, which for most
+// resources is a method value such as testClient().Groups.Get.
+func testCheckGone[T any](get func(context.Context, string) (T, error), id *string) func(*terraform.State) error {
+	return func(*terraform.State) error {
+		if *id == "" {
+			// An empty ID means the test never reached the step that records it,
+			// so reporting success here would assert nothing at all.
+			return errors.New("the destroy check has no ID to look up; the test never recorded one")
+		}
+		_, err := get(context.Background(), *id)
+		if err == nil {
+			return fmt.Errorf("%s still exists on the management server after destroy", *id)
+		}
+		if !netbird.IsNotFound(err) {
+			return fmt.Errorf("checking that %s was deleted: %w", *id, err)
+		}
+		return nil
 	}
 }

--- a/internal/provider/e2e_harness_test.go
+++ b/internal/provider/e2e_harness_test.go
@@ -48,9 +48,11 @@ import (
 	"testing"
 	"time"
 
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/netbirdio/netbird/e2e/harness"
@@ -717,5 +719,56 @@ func testIDChanged(resourceName string, previous *string) resource.TestCheckFunc
 			return fmt.Errorf("%s kept id %s across a change the schema marks RequiresReplace, so it was updated in place instead of being recreated", resourceName, got)
 		}
 		return nil
+	}
+}
+
+// testExpectUpdateInPlace asserts the planned change to a resource is an update
+// rather than a replacement.
+//
+// Comparing IDs across steps proves an object was replaced, but only after the
+// fact and without saying why. This reads the plan itself, so a failure names
+// the action Terraform chose and the attributes that forced it — which is the
+// part that has to change to fix it. Only the attributes that can force a
+// replacement are reported, both because the rest cannot be the cause and
+// because a full dump of the object would carry the plaintext key with it.
+func testExpectUpdateInPlace(address string) plancheck.PlanCheck {
+	return updateInPlace{address: address}
+}
+
+type updateInPlace struct {
+	address string
+}
+
+func (c updateInPlace) CheckPlan(_ context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	for _, rc := range req.Plan.ResourceChanges {
+		if rc.Address != c.address {
+			continue
+		}
+		if slices.Equal(rc.Change.Actions, tfjson.Actions{tfjson.ActionUpdate}) {
+			return
+		}
+		resp.Error = fmt.Errorf("%s: planned %v rather than an in-place update; replacement forced by %v; %s",
+			c.address, rc.Change.Actions, rc.Change.ReplacePaths, describeReplaceable(rc.Change))
+		return
+	}
+	resp.Error = fmt.Errorf("%s is not in the plan", c.address)
+}
+
+// describeReplaceable reports the before and after of every attribute the setup
+// key schema marks RequiresReplace.
+func describeReplaceable(change *tfjson.Change) string {
+	before, _ := change.Before.(map[string]any)
+	after, _ := change.After.(map[string]any)
+	var parts []string
+	for _, attr := range []string{"name", "type", "expiry_seconds", "usage_limit", "ephemeral", "allow_extra_dns_labels"} {
+		parts = append(parts, fmt.Sprintf("%s: %v -> %v", attr, before[attr], after[attr]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// updatesInPlace is testExpectUpdateInPlace as a step's plan checks.
+func updatesInPlace(address string) resource.ConfigPlanChecks {
+	return resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{testExpectUpdateInPlace(address)},
 	}
 }

--- a/internal/provider/e2e_harness_test.go
+++ b/internal/provider/e2e_harness_test.go
@@ -73,7 +73,11 @@ const (
 
 // e2ePeerNames are the hostnames the agent containers register under, in the
 // order the tests expect to find them.
-var e2ePeerNames = []string{"peer1", "peer2", "peer3"}
+// peer4 exists so the delete test has an agent it can consume. Deleting a peer
+// deregisters the device, so a test that asserts deletion cannot use one of the
+// peers the other tests address by name — it would remove a fixture they need,
+// and Go runs peer_acc_test.go before peers_acc_test.go.
+var e2ePeerNames = []string{"peer1", "peer2", "peer3", "peer4"}
 
 // e2eStack is the live deployment plus the IDs of the fixtures created on it.
 type e2eStack struct {
@@ -603,6 +607,24 @@ func testRecordID(resourceName string, into *string) resource.TestCheckFunc {
 	}
 }
 
+// testRecordAttr is testRecordID for any other attribute, which a destroy check
+// needs when the object it must ask about is addressed through a parent — a DNS
+// record lives under the zone in its zone_id, for instance.
+func testRecordAttr(resourceName, attr string, into *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("%s is not in state, so its %s cannot be recorded for the destroy check", resourceName, attr)
+		}
+		v := rs.Primary.Attributes[attr]
+		if v == "" {
+			return fmt.Errorf("%s has no %s attribute in state", resourceName, attr)
+		}
+		*into = v
+		return nil
+	}
+}
+
 // testCheckGone builds a CheckDestroy that requires the recorded object to be
 // absent from the management server. Pass the API's own getter, which for most
 // resources is a method value such as testClient().Groups.Get.
@@ -619,6 +641,28 @@ func testCheckGone[T any](get func(context.Context, string) (T, error), id *stri
 		}
 		if !netbird.IsNotFound(err) {
 			return fmt.Errorf("checking that %s was deleted: %w", *id, err)
+		}
+		return nil
+	}
+}
+
+// testCheckAbsentFromList is the destroy check for a resource whose API has no
+// by-ID getter, so the only way to ask is to list and look. Weaker than
+// testCheckGone — a list error is indistinguishable from an empty list only if
+// it is ignored, so it is returned instead.
+func testCheckAbsentFromList[T any](list func(context.Context) ([]T, error), id func(T) string, want *string) func(*terraform.State) error {
+	return func(*terraform.State) error {
+		if *want == "" {
+			return errors.New("the destroy check has no ID to look for; the test never recorded one")
+		}
+		items, err := list(context.Background())
+		if err != nil {
+			return fmt.Errorf("listing to check that %s was deleted: %w", *want, err)
+		}
+		for _, it := range items {
+			if id(it) == *want {
+				return fmt.Errorf("%s still exists on the management server after destroy", *want)
+			}
 		}
 		return nil
 	}

--- a/internal/provider/group_acc_test.go
+++ b/internal/provider/group_acc_test.go
@@ -16,14 +16,17 @@ func Test_Group_Create(t *testing.T) {
 	testE2E(t)
 	rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_group." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Groups.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testGroupResource(rName, `[]`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					func(s *terraform.State) error {

--- a/internal/provider/group_acc_test.go
+++ b/internal/provider/group_acc_test.go
@@ -42,6 +42,11 @@ func Test_Group_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/identity_provider_acc_test.go
+++ b/internal/provider/identity_provider_acc_test.go
@@ -51,6 +51,12 @@ func Test_IdentityProvider_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:            rNameFull,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_secret"},
+			},
 		},
 	})
 }

--- a/internal/provider/identity_provider_acc_test.go
+++ b/internal/provider/identity_provider_acc_test.go
@@ -18,14 +18,17 @@ func Test_IdentityProvider_Create(t *testing.T) {
 	testE2E(t)
 	rName := "idp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_identity_provider." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().IdentityProviders.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testIdentityProviderResource(rName, "jumpcloud", "oidc", "client-id", "client-secret", "https://oauth.id.jumpcloud.com/"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", "jumpcloud"),
 					resource.TestCheckResourceAttr(rNameFull, "type", "oidc"),
@@ -56,14 +59,17 @@ func Test_IdentityProvider_Update(t *testing.T) {
 	testE2E(t)
 	rName := "idp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_identity_provider." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().IdentityProviders.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testIdentityProviderResource(rName, "jumpcloud", "oidc", "client-id", "client-secret", "https://oauth.id.jumpcloud.com/"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},

--- a/internal/provider/lifecycle_acc_test.go
+++ b/internal/provider/lifecycle_acc_test.go
@@ -4,9 +4,9 @@
 //
 // Two lifecycle behaviours the suite never asserted.
 //
-// Nine resources declare RequiresReplace on 22 attributes between them, which is
-// a promise that changing one recreates the object rather than updating it. No
-// test checked that, and a provider that quietly updated in place would look
+// Eight resources declare RequiresReplace on 18 attributes between them, which
+// is a promise that changing one recreates the object rather than updating it.
+// No test checked that, and a provider that quietly updated in place would look
 // identical to one that recreated — the apply succeeds either way. The tests
 // below change such an attribute and require the server-assigned ID to change
 // with it.

--- a/internal/provider/lifecycle_acc_test.go
+++ b/internal/provider/lifecycle_acc_test.go
@@ -1,0 +1,185 @@
+//go:build e2e
+
+// Replacement and rejection.
+//
+// Two lifecycle behaviours the suite never asserted.
+//
+// Nine resources declare RequiresReplace on 22 attributes between them, which is
+// a promise that changing one recreates the object rather than updating it. No
+// test checked that, and a provider that quietly updated in place would look
+// identical to one that recreated — the apply succeeds either way. The tests
+// below change such an attribute and require the server-assigned ID to change
+// with it.
+//
+// Twenty resources declare 68 validators, and five ExpectError steps existed for
+// all of them, every one in agent_network. A validator that never fires in a test
+// is a rejection nobody has confirmed happens, so each test here feeds one value
+// the validator should refuse and requires the plan to fail. These cost nothing
+// to run: the configuration is rejected before anything reaches the server.
+
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// rejects asserts a configuration is refused, with a message matching want.
+func rejects(t *testing.T, config string, want *regexp.Regexp) {
+	t.Helper()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps:                    []resource.TestStep{{Config: config, ExpectError: want}},
+	})
+}
+
+// oneOf is the message shape terraform-plugin-framework produces for a
+// stringvalidator.OneOf rejection.
+var oneOf = regexp.MustCompile(`(?s)value must be one of|Invalid Attribute Value`)
+
+func Test_SetupKey_Replaced(t *testing.T) {
+	testE2E(t)
+	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_setup_key." + rName
+	var first string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testSetupKeyResource(rName, `1800`, `reusable`, `false`, `[]`, `false`, `false`, `0`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &first),
+					resource.TestCheckResourceAttr(rNameFull, "type", "reusable"),
+				),
+			},
+			{
+				// type is RequiresReplace: a setup key's kind is fixed at creation.
+				Config: testSetupKeyResource(rName, `1800`, `one-off`, `false`, `[]`, `false`, `false`, `0`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "type", "one-off"),
+					testIDChanged(rNameFull, &first),
+				),
+			},
+		},
+	})
+}
+
+func Test_Token_Replaced(t *testing.T) {
+	testE2E(t)
+	rName := "t" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_token." + rName
+	userID := mustE2E().UserID
+	var first string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testTokenResource(rName, userID, `180`),
+				Check:  resource.ComposeAggregateTestCheckFunc(testRecordID(rNameFull, &first)),
+			},
+			{
+				// Every attribute a token has is RequiresReplace, and Update says
+				// so in as many words: "Personal Access Tokens can't be updated".
+				// So changing the expiry has to produce a different token.
+				Config: testTokenResource(rName, userID, `90`),
+				Check:  resource.ComposeAggregateTestCheckFunc(testIDChanged(rNameFull, &first)),
+			},
+		},
+	})
+}
+
+func Test_User_Replaced(t *testing.T) {
+	testE2E(t)
+	rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_user." + rName
+	var first string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testUserResource(rName, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `false`, `user`),
+				Check:  resource.ComposeAggregateTestCheckFunc(testRecordID(rNameFull, &first)),
+			},
+			{
+				// role is not RequiresReplace, so this one must NOT be replaced —
+				// the same assertion in the opposite direction, which is what
+				// distinguishes an in-place update from a recreation.
+				Config: testUserResource(rName, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `false`, `admin`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "role", "admin"),
+					resource.TestCheckResourceAttrPtr(rNameFull, "id", &first),
+				),
+			},
+			{
+				// is_blocked had never been set to true anywhere in the suite, so
+				// the blocking path was written but never exercised. Also in place.
+				Config: testUserResource(rName, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `true`, `admin`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "is_blocked", "true"),
+					resource.TestCheckResourceAttrPtr(rNameFull, "id", &first),
+				),
+			},
+		},
+	})
+}
+
+// The rejection tests. Each feeds one value outside the validator's set.
+
+func Test_SetupKey_RejectsUnknownType(t *testing.T) {
+	testE2E(t)
+	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rejects(t, testSetupKeyResource(rName, `1800`, `perpetual`, `false`, `[]`, `false`, `false`, `0`), oneOf)
+}
+
+func Test_User_RejectsUnknownRole(t *testing.T) {
+	testE2E(t)
+	rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rejects(t, testUserResource(rName, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `false`, `superuser`), oneOf)
+}
+
+func Test_IdentityProvider_RejectsUnknownType(t *testing.T) {
+	testE2E(t)
+	rName := "idp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testIdentityProviderResource(rName, "jumpcloud", "ldap", "client-id", "client-secret",
+		"https://acc.example/oauth2")
+	rejects(t, cfg, oneOf)
+}
+
+func Test_Policy_RejectsUnknownAction(t *testing.T) {
+	testE2E(t)
+	rName := "p" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testPolicyResourceGroups(rName, rName, "desc", "reject", "udp", e2eGroupAllID(), e2eGroupNotAllID(), "443")
+	rejects(t, cfg, oneOf)
+}
+
+func Test_Policy_RejectsUnknownProtocol(t *testing.T) {
+	testE2E(t)
+	rName := "p" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testPolicyResourceGroups(rName, rName, "desc", "accept", "sctp", e2eGroupAllID(), e2eGroupNotAllID(), "443")
+	rejects(t, cfg, oneOf)
+}
+
+func Test_PostureCheck_RejectsUnknownGeoAction(t *testing.T) {
+	testE2E(t)
+	rName := "pc" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testPostureCheckResource(rName, `posture_check`, `0.40.0`, `15`, `10`, `12`, `6.8.0`, `2531`,
+		`EG`, `Cairo`, `permit`, `15.160.0.0/16`, `deny`, `/root`, `C:\\process.exe`, `/macpath`)
+	rejects(t, cfg, oneOf)
+}
+
+func Test_DNSRecord_RejectsUnknownType(t *testing.T) {
+	testE2E(t)
+	zoneName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	// MX is a real record type, and not one this provider accepts.
+	cfg := testDNSRecordResource(zoneName, "reject.local", rName, "mail", "MX", "10 mail.reject.local", 300)
+	rejects(t, cfg, oneOf)
+}

--- a/internal/provider/lifecycle_acc_test.go
+++ b/internal/provider/lifecycle_acc_test.go
@@ -55,7 +55,7 @@ func Test_SetupKey_Replaced(t *testing.T) {
 				// usage_limit is left out of both steps: the server fixes it at
 				// 1 for a one-off key, so a configuration that names 0 for both
 				// steps is asking the second one for something it cannot have.
-				Config: testSetupKeyResourceNoLimit(rName, `reusable`, `[]`),
+				Config: testSetupKeyResourceNoLimit(rName, `reusable`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testRecordID(rNameFull, &first),
 					resource.TestCheckResourceAttr(rNameFull, "type", "reusable"),
@@ -63,7 +63,7 @@ func Test_SetupKey_Replaced(t *testing.T) {
 			},
 			{
 				// type is RequiresReplace: a setup key's kind is fixed at creation.
-				Config: testSetupKeyResourceNoLimit(rName, `one-off`, `[]`),
+				Config: testSetupKeyResourceNoLimit(rName, `one-off`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(rNameFull, "type", "one-off"),
 					testIDChanged(rNameFull, &first),

--- a/internal/provider/lifecycle_acc_test.go
+++ b/internal/provider/lifecycle_acc_test.go
@@ -52,7 +52,10 @@ func Test_SetupKey_Replaced(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testSetupKeyResource(rName, `1800`, `reusable`, `false`, `[]`, `false`, `false`, `0`),
+				// usage_limit is left out of both steps: the server fixes it at
+				// 1 for a one-off key, so a configuration that names 0 for both
+				// steps is asking the second one for something it cannot have.
+				Config: testSetupKeyResourceNoLimit(rName, `reusable`, `[]`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testRecordID(rNameFull, &first),
 					resource.TestCheckResourceAttr(rNameFull, "type", "reusable"),
@@ -60,7 +63,7 @@ func Test_SetupKey_Replaced(t *testing.T) {
 			},
 			{
 				// type is RequiresReplace: a setup key's kind is fixed at creation.
-				Config: testSetupKeyResource(rName, `1800`, `one-off`, `false`, `[]`, `false`, `false`, `0`),
+				Config: testSetupKeyResourceNoLimit(rName, `one-off`, `[]`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(rNameFull, "type", "one-off"),
 					testIDChanged(rNameFull, &first),

--- a/internal/provider/nameserver_group_acc_test.go
+++ b/internal/provider/nameserver_group_acc_test.go
@@ -16,14 +16,17 @@ func Test_NameserverGroup_Create(t *testing.T) {
 	testE2E(t)
 	rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_nameserver_group." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().DNS.GetNameserverGroup, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testNameserverGroupResource(rName, `1.1.1.1`, `53`, fmt.Sprintf("[%q]", e2eGroupAllID())),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					func(s *terraform.State) error {
@@ -65,14 +68,17 @@ func Test_NameserverGroup_Update(t *testing.T) {
 	testE2E(t)
 	rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_nameserver_group." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().DNS.GetNameserverGroup, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testNameserverGroupResource(rName, `1.1.1.1`, `53`, fmt.Sprintf("[%q]", e2eGroupAllID())),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},

--- a/internal/provider/nameserver_group_acc_test.go
+++ b/internal/provider/nameserver_group_acc_test.go
@@ -60,6 +60,11 @@ func Test_NameserverGroup_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/network_acc_test.go
+++ b/internal/provider/network_acc_test.go
@@ -16,14 +16,17 @@ func Test_Network_Create(t *testing.T) {
 	testE2E(t)
 	rName := "n" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_network." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Networks.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testNetworkResource(rName, `Test`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					resource.TestCheckResourceAttr(rNameFull, "description", `Test`),
@@ -57,14 +60,17 @@ func Test_Network_Update(t *testing.T) {
 	testE2E(t)
 	rName := "n" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_network." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Networks.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testNetworkResource(rName, `Test`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},

--- a/internal/provider/network_acc_test.go
+++ b/internal/provider/network_acc_test.go
@@ -52,6 +52,11 @@ func Test_Network_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/network_resource_acc_test.go
+++ b/internal/provider/network_resource_acc_test.go
@@ -10,20 +10,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
 )
 
 func Test_NetworkResource_Create(t *testing.T) {
 	testE2E(t)
 	rName := "nre" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_network_resource." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testCheckGone(func(ctx context.Context, id string) (*api.NetworkResource, error) {
+			return testClient().Networks.Resources(e2eNetworkID()).Get(ctx, id)
+		}, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testNetworkResourceResource(rName, e2eNetworkID(), `example.com`, fmt.Sprintf("[%q, %q]", e2eGroupNotAllID(), e2eGroupAllID()), rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "address", "example.com"),
 					resource.TestCheckResourceAttr(rNameFull, "groups.#", "2"),
@@ -59,14 +66,19 @@ func Test_NetworkResource_Update(t *testing.T) {
 	testE2E(t)
 	rName := "nre" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_network_resource." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testCheckGone(func(ctx context.Context, id string) (*api.NetworkResource, error) {
+			return testClient().Networks.Resources(e2eNetworkID()).Get(ctx, id)
+		}, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testNetworkResourceResource(rName, e2eNetworkID(), `example.com`, fmt.Sprintf("[%q]", e2eGroupNotAllID()), rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},

--- a/internal/provider/network_resource_acc_test.go
+++ b/internal/provider/network_resource_acc_test.go
@@ -58,6 +58,12 @@ func Test_NetworkResource_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testImportIDFrom(rNameFull, "/", "network_id", "id"),
+			},
 		},
 	})
 }

--- a/internal/provider/network_router_acc_test.go
+++ b/internal/provider/network_router_acc_test.go
@@ -52,6 +52,12 @@ func Test_NetworkRouter_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testImportIDFrom(rNameFull, "/", "network_id", "id"),
+			},
 		},
 	})
 }

--- a/internal/provider/network_router_acc_test.go
+++ b/internal/provider/network_router_acc_test.go
@@ -10,20 +10,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
 )
 
 func Test_NetworkRouter_Create(t *testing.T) {
 	testE2E(t)
 	rName := "nro" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_network_router." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testCheckGone(func(ctx context.Context, id string) (*api.NetworkRouter, error) {
+			return testClient().Networks.Routers(e2eNetworkID()).Get(ctx, id)
+		}, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testNetworkRouterResource(rName, e2eNetworkID(), fmt.Sprintf("[%q]", e2eGroupNotAllID())),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "peer_groups.#", `1`),
 					resource.TestCheckResourceAttr(rNameFull, "peer_groups.0", e2eGroupNotAllID()),
@@ -53,14 +60,19 @@ func Test_NetworkRouter_Update(t *testing.T) {
 	testE2E(t)
 	rName := "nro" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_network_router." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testCheckGone(func(ctx context.Context, id string) (*api.NetworkRouter, error) {
+			return testClient().Networks.Routers(e2eNetworkID()).Get(ctx, id)
+		}, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testNetworkRouterResource(rName, e2eNetworkID(), fmt.Sprintf("[%q]", e2eGroupNotAllID())),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "peer_groups.#", `1`),
 					resource.TestCheckResourceAttr(rNameFull, "peer_groups.0", e2eGroupNotAllID()),

--- a/internal/provider/peer_acc_test.go
+++ b/internal/provider/peer_acc_test.go
@@ -83,6 +83,42 @@ func Test_Peer_Update(t *testing.T) {
 	})
 }
 
+// Test_Peer_Delete asserts that destroying a netbird_peer deregisters the device.
+//
+// This FAILS on the current provider, deliberately: Peer.Delete skips the API
+// call whenever TF_ACC is set in the environment, so under the acceptance suite
+// the one path this test exists to cover is switched off. The peer survives the
+// destroy and the assertion below reports it as still present.
+//
+// The switch is in shipped code rather than in a test, so it is not only a
+// coverage gap: any user with TF_ACC in their environment gets a provider whose
+// terraform destroy reports success while the peer stays registered. Removing
+// that branch is what makes this test pass.
+//
+// It consumes peer4 rather than one of peer1-3, because deleting a peer
+// deregisters the device and the other tests address those by name.
+func Test_Peer_Delete(t *testing.T) {
+	testE2E(t)
+	rName := "p" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_peer." + rName
+	peerID := testPeerID(t, "peer4")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Peers.Get, &peerID),
+		Steps: []resource.TestStep{
+			{
+				ResourceName: rName,
+				Config:       testPeerResource(rName, peerID, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rNameFull, "id", peerID),
+					resource.TestCheckResourceAttr(rNameFull, "name", rName),
+				),
+			},
+		},
+	})
+}
+
 func testPeerResource(rName, id, name string) string {
 	return fmt.Sprintf(`resource "netbird_peer" "%s" {
 	id = "%s"

--- a/internal/provider/peer_acc_test.go
+++ b/internal/provider/peer_acc_test.go
@@ -22,7 +22,7 @@ func Test_Peer_Create(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
-				Config:       testPeerResource(rName, testPeerID(t, "peer2"), rName),
+				Config:       testPeerResource(rName, testPeerID(t, "peer3"), rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
@@ -41,6 +41,11 @@ func Test_Peer_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -55,14 +60,14 @@ func Test_Peer_Update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
-				Config:       testPeerResource(rName, testPeerID(t, "peer3"), "meow"),
+				Config:       testPeerResource(rName, testPeerID(t, "peer4"), "meow"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},
 			{
 				ResourceName: rName,
-				Config:       testPeerResource(rName, testPeerID(t, "peer3"), rName),
+				Config:       testPeerResource(rName, testPeerID(t, "peer4"), rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
@@ -95,13 +100,14 @@ func Test_Peer_Update(t *testing.T) {
 // terraform destroy reports success while the peer stays registered. Removing
 // that branch is what makes this test pass.
 //
-// It consumes peer4 rather than one of peer1-3, because deleting a peer
-// deregisters the device and the other tests address those by name.
+// It consumes peer5, one of the fixtures reserved for tests that manage a peer
+// through its own lifecycle: deleting a peer deregisters the device, and the
+// shared fixtures are addressed by name elsewhere in the suite.
 func Test_Peer_Delete(t *testing.T) {
 	testE2E(t)
 	rName := "p" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_peer." + rName
-	peerID := testPeerID(t, "peer4")
+	peerID := testPeerID(t, "peer5")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/peer_acc_test.go
+++ b/internal/provider/peer_acc_test.go
@@ -37,7 +37,36 @@ func Test_Peer_Create(t *testing.T) {
 							return fmt.Errorf("Peer name mismatch, expected %s, found %s on management server", rName, peer.Name)
 						}
 
-						return nil
+						// Every attribute the provider maps from the API, compared
+						// against what the API says. 19 of the peer schema's 25
+						// attributes are computed from the response and only two
+						// were asserted anywhere, so a field mapped to the wrong
+						// source — or not mapped at all — produced a state Terraform
+						// was happy with and no test could see.
+						attrs := s.RootModule().Resources[rNameFull].Primary.Attributes
+						return matchPairs(map[string][]any{
+							"os":                            {attrs["os"], peer.Os},
+							"ip":                            {attrs["ip"], peer.Ip},
+							"hostname":                      {attrs["hostname"], peer.Hostname},
+							"dns_label":                     {attrs["dns_label"], peer.DnsLabel},
+							"connection_ip":                 {attrs["connection_ip"], peer.ConnectionIp},
+							"kernel_version":                {attrs["kernel_version"], peer.KernelVersion},
+							"serial_number":                 {attrs["serial_number"], peer.SerialNumber},
+							"ui_version":                    {attrs["ui_version"], peer.UiVersion},
+							"version":                       {attrs["version"], peer.Version},
+							"user_id":                       {attrs["user_id"], peer.UserId},
+							"city_name":                     {attrs["city_name"], peer.CityName},
+							"country_code":                  {attrs["country_code"], peer.CountryCode},
+							"geoname_id":                    {attrs["geoname_id"], fmt.Sprint(peer.GeonameId)},
+							"connected":                     {attrs["connected"], fmt.Sprint(peer.Connected)},
+							"login_expired":                 {attrs["login_expired"], fmt.Sprint(peer.LoginExpired)},
+							"ssh_enabled":                   {attrs["ssh_enabled"], fmt.Sprint(peer.SshEnabled)},
+							"approval_required":             {attrs["approval_required"], fmt.Sprint(peer.ApprovalRequired)},
+							"login_expiration_enabled":      {attrs["login_expiration_enabled"], fmt.Sprint(peer.LoginExpirationEnabled)},
+							"inactivity_expiration_enabled": {attrs["inactivity_expiration_enabled"], fmt.Sprint(peer.InactivityExpirationEnabled)},
+							"groups.#":                      {attrs["groups.#"], fmt.Sprint(len(peer.Groups))},
+							"extra_dns_labels.#":            {attrs["extra_dns_labels.#"], fmt.Sprint(len(peer.ExtraDnsLabels))},
+						})
 					},
 				),
 			},

--- a/internal/provider/policy_acc_test.go
+++ b/internal/provider/policy_acc_test.go
@@ -16,14 +16,17 @@ func Test_Policy_Create_Groups(t *testing.T) {
 	testE2E(t)
 	rName := "po" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_policy." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Policies.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testPolicyResourceGroups(rName, rName, "desc", "accept", "udp", e2eGroupAllID(), e2eGroupNotAllID(), "443"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					resource.TestCheckResourceAttr(rNameFull, "description", "desc"),
@@ -65,14 +68,17 @@ func Test_Policy_Create_Resources(t *testing.T) {
 	testE2E(t)
 	rName := "po" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_policy." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Policies.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testPolicyResourceResources(rName, rName, "desc", "accept", "udp", e2eResourceSubnetID(), "subnet", e2eResourceDomainID(), "domain", "1000", "2000"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					resource.TestCheckResourceAttr(rNameFull, "description", "desc"),
@@ -120,14 +126,17 @@ func Test_Policy_Update_Groups(t *testing.T) {
 	testE2E(t)
 	rName := "po" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_policy." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Policies.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testPolicyResourceGroups(rName, rName, "desc", "accept", "udp", e2eGroupAllID(), e2eGroupNotAllID(), "443"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},
@@ -175,14 +184,17 @@ func Test_Policy_Update_Resources(t *testing.T) {
 	testE2E(t)
 	rName := "po" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_policy." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Policies.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testPolicyResourceGroups(rName, rName, "desc", "accept", "udp", e2eGroupAllID(), e2eGroupNotAllID(), "80"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},

--- a/internal/provider/policy_acc_test.go
+++ b/internal/provider/policy_acc_test.go
@@ -60,6 +60,11 @@ func Test_Policy_Create_Groups(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/posture_check_acc_test.go
+++ b/internal/provider/posture_check_acc_test.go
@@ -77,6 +77,11 @@ func Test_PostureCheck_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/posture_check_acc_test.go
+++ b/internal/provider/posture_check_acc_test.go
@@ -16,14 +16,17 @@ func Test_PostureCheck_Create(t *testing.T) {
 	testE2E(t)
 	rName := "pc" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_posture_check." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().PostureChecks.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testPostureCheckResource(rName, `posture_check`, `0.40.0`, `15`, `10`, `12`, `6.8.0`, `2531`, `EG`, `Cairo`, `allow`, `15.160.0.0/16`, `deny`, `/root`, `C:\\process.exe`, `/macpath`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					resource.TestCheckResourceAttr(rNameFull, "description", "posture_check"),
@@ -82,14 +85,17 @@ func Test_PostureCheck_Update(t *testing.T) {
 	testE2E(t)
 	rName := "pc" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_posture_check." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().PostureChecks.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testPostureCheckResource(rName, `posture_check`, `0.40.0`, `15`, `10`, `12`, `6.8.0`, `2531`, `EG`, `Cairo`, `allow`, `15.160.0.0/16`, `deny`, `/root`, `C:\\process.exe`, `/macpath`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},

--- a/internal/provider/reverse_proxy_acc_test.go
+++ b/internal/provider/reverse_proxy_acc_test.go
@@ -239,15 +239,18 @@ func Test_ReverseProxyService_PinAuth(t *testing.T) {
 	rName := "s" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 	domain := rName + "." + cluster.Address
 	rNameFull := "netbird_reverse_proxy_service." + rName
+	var createdID string
 	peerID := testPeerID(t, "peer1")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().ReverseProxyServices.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				Config: testReverseProxyServicePinAuth(rName, domain, peerID, "9876"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "auth.pin_auth.enabled", "true"),
 					resource.TestCheckResourceAttr(rNameFull, "auth.pin_auth.pin", "9876"),
@@ -273,16 +276,19 @@ func Test_ReverseProxyService_BearerAuth(t *testing.T) {
 	rName := "s" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 	domain := rName + "." + cluster.Address
 	rNameFull := "netbird_reverse_proxy_service." + rName
+	var createdID string
 	peerID := testPeerID(t, "peer1")
 	groupID := e2eGroupAllID()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().ReverseProxyServices.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				Config: testReverseProxyServiceBearerAuth(rName, domain, peerID, groupID),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "auth.bearer_auth.enabled", "true"),
 					resource.TestCheckResourceAttr(rNameFull, "auth.bearer_auth.distribution_groups.#", "1"),
@@ -312,16 +318,19 @@ func Test_ReverseProxyService_MultipleTargets(t *testing.T) {
 	rName := "s" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
 	domain := rName + "." + cluster.Address
 	rNameFull := "netbird_reverse_proxy_service." + rName
+	var createdID string
 	peerID1 := testPeerID(t, "peer1")
 	peerID2 := testPeerID(t, "peer2")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().ReverseProxyServices.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				Config: testReverseProxyServiceMultiTarget(rName, domain, peerID1, peerID2),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "targets.#", "2"),
 					func(s *terraform.State) error {

--- a/internal/provider/route_acc_test.go
+++ b/internal/provider/route_acc_test.go
@@ -60,6 +60,11 @@ func Test_Route_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/route_acc_test.go
+++ b/internal/provider/route_acc_test.go
@@ -16,14 +16,17 @@ func Test_Route_Create(t *testing.T) {
 	testE2E(t)
 	rName := "pc" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_route." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Routes.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testRouteResource(rName, e2eGroupAllID(), `null`, `desc`, `null`, `["example.com"]`, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `null`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "network_id", rName),
 					resource.TestCheckResourceAttr(rNameFull, "groups.#", "1"),
@@ -65,6 +68,7 @@ func Test_Route_Update(t *testing.T) {
 	testE2E(t)
 	rName := "pc" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_route." + rName
+	var createdID string
 	// Resolved once, up front: the fixture helpers can fail the test, and doing
 	// that from inside a Check closure aborts the run mid-apply, before
 	// terraform-plugin-testing gets to its destroy step.
@@ -72,11 +76,13 @@ func Test_Route_Update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Routes.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testRouteResource(rName, e2eGroupAllID(), `null`, `desc`, `null`, `["example.com"]`, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `null`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 				),
 			},

--- a/internal/provider/scim_acc_test.go
+++ b/internal/provider/scim_acc_test.go
@@ -53,6 +53,12 @@ func Test_Scim_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:            rNameFull,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_token"},
+			},
 		},
 	})
 }

--- a/internal/provider/setup_key_acc_test.go
+++ b/internal/provider/setup_key_acc_test.go
@@ -16,14 +16,17 @@ func Test_SetupKey_Create(t *testing.T) {
 	testE2E(t)
 	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_setup_key." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().SetupKeys.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testSetupKeyResource(rName, `1800`, `reusable`, `false`, `[]`, `false`, `false`, `0`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttrSet(rNameFull, "expires"),
 					resource.TestCheckResourceAttrSet(rNameFull, "key"),
@@ -61,9 +64,11 @@ func Test_SetupKey_Update_Groups(t *testing.T) {
 	testE2E(t)
 	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_setup_key." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().SetupKeys.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
@@ -74,6 +79,7 @@ func Test_SetupKey_Update_Groups(t *testing.T) {
 				ResourceName: rName,
 				Config:       testSetupKeyResource(rName, `1800`, `one-off`, `true`, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `true`, `false`, `1`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttrSet(rNameFull, "expires"),
 					resource.TestCheckResourceAttrSet(rNameFull, "key"),
@@ -113,9 +119,11 @@ func Test_SetupKey_Update_Revoke(t *testing.T) {
 	testE2E(t)
 	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_setup_key." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().SetupKeys.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
@@ -126,6 +134,7 @@ func Test_SetupKey_Update_Revoke(t *testing.T) {
 				ResourceName: rName,
 				Config:       testSetupKeyResource(rName, `3600`, `reusable`, `false`, `[]`, `false`, `true`, `10`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttrSet(rNameFull, "expires"),
 					resource.TestCheckResourceAttrSet(rNameFull, "key"),

--- a/internal/provider/setup_key_acc_test.go
+++ b/internal/provider/setup_key_acc_test.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -57,10 +58,15 @@ func Test_SetupKey_Create(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            rNameFull,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"key"},
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Neither of these can be read back. The plaintext key is
+				// returned once, at creation. expiry_seconds is never returned
+				// at all: the API reports an absolute expiry date and no
+				// creation date, so the lifetime the key was created with
+				// cannot be recovered from it.
+				ImportStateVerifyIgnore: []string{"key", "expiry_seconds"},
 			},
 		},
 	})
@@ -121,6 +127,100 @@ func Test_SetupKey_Update_Groups(t *testing.T) {
 	})
 }
 
+// Test_SetupKey_Update_Groups_AddRemove covers what a user actually does to a
+// setup key after creating it: attach groups, attach more, take some away, take
+// them all away. The pre-existing group test only ever went from no groups to
+// one group, so nothing asserted that removal reaches the server, that more than
+// one group is handled, or — the part that was reported broken — that any of it
+// is an update rather than a replacement.
+//
+// The key here deliberately leaves usage_limit unset, which is the only way to
+// write a one-off key: the server fixes the limit of a one-off key at 1 and
+// ignores what the request asked for. Recording the ID up front and checking it
+// after every step is what distinguishes an update from a destroy-and-recreate,
+// and a recreated setup key is a different secret — every peer still holding the
+// old one can no longer register.
+func Test_SetupKey_Update_Groups_AddRemove(t *testing.T) {
+	testE2E(t)
+	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	rNameFull := "netbird_setup_key." + rName
+	var createdID string
+	// Same ID, asserted at every step after the first.
+	sameKey := func() resource.TestCheckFunc {
+		return resource.TestCheckResourceAttrPtr(rNameFull, "id", &createdID)
+	}
+	groupsAre := func(want ...string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			sk, err := testClient().SetupKeys.Get(context.Background(), createdID)
+			if err != nil {
+				return err
+			}
+			if len(sk.AutoGroups) != len(want) {
+				return fmt.Errorf("management has %d auto groups, expected %d", len(sk.AutoGroups), len(want))
+			}
+			for _, id := range want {
+				if !slices.Contains(sk.AutoGroups, id) {
+					return fmt.Errorf("group %s missing from auto groups %v", id, sk.AutoGroups)
+				}
+			}
+			return nil
+		}
+	}
+	all, notAll := e2eGroupAllID(), e2eGroupNotAllID()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().SetupKeys.Get, &createdID),
+		Steps: []resource.TestStep{
+			{
+				Config: testSetupKeyResourceNoLimit(rName, `one-off`, `[]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
+					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "0"),
+					// The server pins a one-off key to a single use whatever
+					// the request said, so this is the server's value, not a
+					// configured one.
+					resource.TestCheckResourceAttr(rNameFull, "usage_limit", "1"),
+				),
+			},
+			{
+				Config: testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q]", notAll)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					sameKey(),
+					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "auto_groups.0", notAll),
+					groupsAre(notAll),
+				),
+			},
+			{
+				Config: testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q, %q]", notAll, all)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					sameKey(),
+					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "2"),
+					groupsAre(notAll, all),
+				),
+			},
+			{
+				Config: testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q]", all)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					sameKey(),
+					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "1"),
+					resource.TestCheckResourceAttr(rNameFull, "auto_groups.0", all),
+					groupsAre(all),
+				),
+			},
+			{
+				Config: testSetupKeyResourceNoLimit(rName, `one-off`, `[]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					sameKey(),
+					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "0"),
+					groupsAre(),
+				),
+			},
+		},
+	})
+}
+
 func Test_SetupKey_Update_Revoke(t *testing.T) {
 	testE2E(t)
 	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
@@ -172,6 +272,21 @@ func Test_SetupKey_Update_Revoke(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testSetupKeyResourceNoLimit omits usage_limit, and with it the optional flags
+// the reported problem does not involve. A one-off key has to be written this
+// way: the server decides its usage limit, so naming one in the configuration
+// either contradicts the server or repeats it. The expiry is fixed at half an
+// hour because none of these tests are about expiry.
+func testSetupKeyResourceNoLimit(rName, skType, groups string) string {
+	return fmt.Sprintf(`resource "netbird_setup_key" "%[1]s" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "%[2]s"
+  auto_groups    = %[3]s
+}
+`, rName, skType, groups)
 }
 
 func testSetupKeyResource(rName, expiry, skType, allowExtraDNS, groups, ephemeral, revoked, usageLimit string) string {

--- a/internal/provider/setup_key_acc_test.go
+++ b/internal/provider/setup_key_acc_test.go
@@ -134,29 +134,43 @@ func Test_SetupKey_Update_Groups(t *testing.T) {
 // one group is handled, or — the part that was reported broken — that any of it
 // is an update rather than a replacement.
 //
-// The key here deliberately leaves usage_limit unset, which is the only way to
-// write a one-off key: the server fixes the limit of a one-off key at 1 and
-// ignores what the request asked for. Recording the ID up front and checking it
-// after every step is what distinguishes an update from a destroy-and-recreate,
-// and a recreated setup key is a different secret — every peer still holding the
-// old one can no longer register.
+// Each step requires Terraform to have planned an in-place update, which is the
+// assertion that reports the reported bug: a replaced setup key is a different
+// secret, so every peer still holding the old one stops being able to register.
+// The ID is checked as well, since a plan can be right and the apply still wrong.
+//
+// The key deliberately leaves usage_limit unset, which is the only way to write
+// a one-off key: the server fixes the limit of a one-off key at 1 and ignores
+// what the request asked for.
 func Test_SetupKey_Update_Groups_AddRemove(t *testing.T) {
 	testE2E(t)
 	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_setup_key." + rName
+	groupA, groupB := "netbird_group."+rName+"a", "netbird_group."+rName+"b"
 	var createdID string
 	// Same ID, asserted at every step after the first.
 	sameKey := func() resource.TestCheckFunc {
 		return resource.TestCheckResourceAttrPtr(rNameFull, "id", &createdID)
 	}
-	groupsAre := func(want ...string) resource.TestCheckFunc {
+	// groupsAre reads the wanted IDs out of state rather than taking them as
+	// literals, because the groups are created by the same configuration and
+	// their IDs are not known until it has been applied.
+	groupsAre := func(addresses ...string) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
+			want := make([]string, 0, len(addresses))
+			for _, a := range addresses {
+				rs, ok := s.RootModule().Resources[a]
+				if !ok {
+					return fmt.Errorf("%s is not in state", a)
+				}
+				want = append(want, rs.Primary.Attributes["id"])
+			}
 			sk, err := testClient().SetupKeys.Get(context.Background(), createdID)
 			if err != nil {
 				return err
 			}
 			if len(sk.AutoGroups) != len(want) {
-				return fmt.Errorf("management has %d auto groups, expected %d", len(sk.AutoGroups), len(want))
+				return fmt.Errorf("management has %d auto groups %v, expected %d", len(sk.AutoGroups), sk.AutoGroups, len(want))
 			}
 			for _, id := range want {
 				if !slices.Contains(sk.AutoGroups, id) {
@@ -166,54 +180,53 @@ func Test_SetupKey_Update_Groups_AddRemove(t *testing.T) {
 			return nil
 		}
 	}
-	all, notAll := e2eGroupAllID(), e2eGroupNotAllID()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckGone(testClient().SetupKeys.Get, &createdID),
 		Steps: []resource.TestStep{
 			{
-				Config: testSetupKeyResourceNoLimit(rName, `one-off`, `[]`),
+				Config: testSetupKeyWithGroups(rName, `[]`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "0"),
 					// The server pins a one-off key to a single use whatever
-					// the request said, so this is the server's value, not a
-					// configured one.
+					// the request said, so this is the server's value rather
+					// than a configured one.
 					resource.TestCheckResourceAttr(rNameFull, "usage_limit", "1"),
 				),
 			},
 			{
-				Config:           testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q]", notAll)),
+				Config:           testSetupKeyWithGroups(rName, fmt.Sprintf("[%s.id]", groupA)),
 				ConfigPlanChecks: updatesInPlace(rNameFull),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					sameKey(),
 					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "1"),
-					resource.TestCheckResourceAttr(rNameFull, "auto_groups.0", notAll),
-					groupsAre(notAll),
+					resource.TestCheckResourceAttrPair(rNameFull, "auto_groups.0", groupA, "id"),
+					groupsAre(groupA),
 				),
 			},
 			{
-				Config:           testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q, %q]", notAll, all)),
+				Config:           testSetupKeyWithGroups(rName, fmt.Sprintf("[%s.id, %s.id]", groupA, groupB)),
 				ConfigPlanChecks: updatesInPlace(rNameFull),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					sameKey(),
 					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "2"),
-					groupsAre(notAll, all),
+					groupsAre(groupA, groupB),
 				),
 			},
 			{
-				Config:           testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q]", all)),
+				Config:           testSetupKeyWithGroups(rName, fmt.Sprintf("[%s.id]", groupB)),
 				ConfigPlanChecks: updatesInPlace(rNameFull),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					sameKey(),
 					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "1"),
-					resource.TestCheckResourceAttr(rNameFull, "auto_groups.0", all),
-					groupsAre(all),
+					resource.TestCheckResourceAttrPair(rNameFull, "auto_groups.0", groupB, "id"),
+					groupsAre(groupB),
 				),
 			},
 			{
-				Config:           testSetupKeyResourceNoLimit(rName, `one-off`, `[]`),
+				Config:           testSetupKeyWithGroups(rName, `[]`),
 				ConfigPlanChecks: updatesInPlace(rNameFull),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					sameKey(),
@@ -223,6 +236,30 @@ func Test_SetupKey_Update_Groups_AddRemove(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testSetupKeyWithGroups builds a one-off key alongside the two groups it
+// attaches. They are created here rather than taken from the fixtures because
+// the account's "All" group cannot be attached to a setup key at all — the
+// server refuses it — which leaves only one fixture group to work with.
+func testSetupKeyWithGroups(rName, groups string) string {
+	return fmt.Sprintf(`resource "netbird_group" "%[1]sa" {
+  name  = "%[1]sa"
+  peers = []
+}
+
+resource "netbird_group" "%[1]sb" {
+  name  = "%[1]sb"
+  peers = []
+}
+
+resource "netbird_setup_key" "%[1]s" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "one-off"
+  auto_groups    = %[2]s
+}
+`, rName, groups)
 }
 
 func Test_SetupKey_Update_Revoke(t *testing.T) {
@@ -279,18 +316,17 @@ func Test_SetupKey_Update_Revoke(t *testing.T) {
 }
 
 // testSetupKeyResourceNoLimit omits usage_limit, and with it the optional flags
-// the reported problem does not involve. A one-off key has to be written this
-// way: the server decides its usage limit, so naming one in the configuration
-// either contradicts the server or repeats it. The expiry is fixed at half an
-// hour because none of these tests are about expiry.
-func testSetupKeyResourceNoLimit(rName, skType, groups string) string {
+// and groups the test using it does not involve. A one-off key has to be
+// written this way: the server decides its usage limit, so naming one in the
+// configuration either contradicts the server or repeats it.
+func testSetupKeyResourceNoLimit(rName, skType string) string {
 	return fmt.Sprintf(`resource "netbird_setup_key" "%[1]s" {
   name           = "%[1]s"
   expiry_seconds = 1800
   type           = "%[2]s"
-  auto_groups    = %[3]s
+  auto_groups    = []
 }
-`, rName, skType, groups)
+`, rName, skType)
 }
 
 func testSetupKeyResource(rName, expiry, skType, allowExtraDNS, groups, ephemeral, revoked, usageLimit string) string {

--- a/internal/provider/setup_key_acc_test.go
+++ b/internal/provider/setup_key_acc_test.go
@@ -184,7 +184,8 @@ func Test_SetupKey_Update_Groups_AddRemove(t *testing.T) {
 				),
 			},
 			{
-				Config: testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q]", notAll)),
+				Config:           testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q]", notAll)),
+				ConfigPlanChecks: updatesInPlace(rNameFull),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					sameKey(),
 					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "1"),
@@ -193,7 +194,8 @@ func Test_SetupKey_Update_Groups_AddRemove(t *testing.T) {
 				),
 			},
 			{
-				Config: testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q, %q]", notAll, all)),
+				Config:           testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q, %q]", notAll, all)),
+				ConfigPlanChecks: updatesInPlace(rNameFull),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					sameKey(),
 					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "2"),
@@ -201,7 +203,8 @@ func Test_SetupKey_Update_Groups_AddRemove(t *testing.T) {
 				),
 			},
 			{
-				Config: testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q]", all)),
+				Config:           testSetupKeyResourceNoLimit(rName, `one-off`, fmt.Sprintf("[%q]", all)),
+				ConfigPlanChecks: updatesInPlace(rNameFull),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					sameKey(),
 					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "1"),
@@ -210,7 +213,8 @@ func Test_SetupKey_Update_Groups_AddRemove(t *testing.T) {
 				),
 			},
 			{
-				Config: testSetupKeyResourceNoLimit(rName, `one-off`, `[]`),
+				Config:           testSetupKeyResourceNoLimit(rName, `one-off`, `[]`),
+				ConfigPlanChecks: updatesInPlace(rNameFull),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					sameKey(),
 					resource.TestCheckResourceAttr(rNameFull, "auto_groups.#", "0"),

--- a/internal/provider/setup_key_acc_test.go
+++ b/internal/provider/setup_key_acc_test.go
@@ -56,6 +56,12 @@ func Test_SetupKey_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:            rNameFull,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key"},
+			},
 		},
 	})
 }

--- a/internal/provider/token_acc_test.go
+++ b/internal/provider/token_acc_test.go
@@ -10,20 +10,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
 )
 
 func Test_Token_Create(t *testing.T) {
 	testE2E(t)
 	rName := "t" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_token." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testCheckGone(func(ctx context.Context, id string) (*api.PersonalAccessToken, error) {
+			return testClient().Tokens.Get(ctx, mustE2E().UserID, id)
+		}, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testTokenResource(rName, mustE2E().UserID, `180`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttrSet(rNameFull, "token"),
 					resource.TestCheckResourceAttrSet(rNameFull, "expiration_date"),

--- a/internal/provider/token_acc_test.go
+++ b/internal/provider/token_acc_test.go
@@ -50,6 +50,13 @@ func Test_Token_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:            rNameFull,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testImportIDFrom(rNameFull, "/", "user_id", "id"),
+				ImportStateVerifyIgnore: []string{"token"},
+			},
 		},
 	})
 }

--- a/internal/provider/user_acc_test.go
+++ b/internal/provider/user_acc_test.go
@@ -68,6 +68,11 @@ func Test_User_Create(t *testing.T) {
 					},
 				),
 			},
+			{
+				ResourceName:      rNameFull,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/provider/user_acc_test.go
+++ b/internal/provider/user_acc_test.go
@@ -17,14 +17,18 @@ func Test_User_Create(t *testing.T) {
 	testE2E(t)
 	rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	rNameFull := "netbird_user." + rName
+	var createdID string
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testEnsureManagementRunning(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testCheckAbsentFromList(testClient().Users.List,
+			func(u api.User) string { return u.Id }, &createdID),
 		Steps: []resource.TestStep{
 			{
 				ResourceName: rName,
 				Config:       testUserResource(rName, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `false`, `user`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(rNameFull, &createdID),
 					resource.TestCheckResourceAttrSet(rNameFull, "id"),
 					resource.TestCheckResourceAttr(rNameFull, "name", rName),
 					resource.TestCheckResourceAttr(rNameFull, "is_service_user", "true"),


### PR DESCRIPTION
Third of five. Stacked on #198 — review that first; this diff is against it.

> [!IMPORTANT]
> **This PR is expected to fail CI**, and #201 is what turns it green. The failures are the deliverable: each one is a provider defect these tests were written to surface. Everything else passes.

## Why

The suite had 66 acceptance tests and looked thorough. Measured per operation rather than per test, most of the Terraform lifecycle was unasserted:

| Operation | Before | After |
| --- | --- | --- |
| Destroy — is the object actually gone? | 3 of 66 tests | **41** |
| Import — 23 resources support it | 3 tested | **23** |
| Data sources — 25 exist | 6 tested | **23** |
| Replacement — 18 `RequiresReplace` attributes | 0 tested | **3 resources** |
| Validator rejection — 68 validators | 5 steps, all in one file | **12** |
| Attribute surface — 271 schema attributes | 106 referenced (39%) | **150 (55%)** |

Each row is a way for the provider to be wrong while CI stayed green, because Terraform reports success in all of them: state is updated whether or not the server agreed, a plan is empty whether or not the read mapped the right field, and an apply succeeds whether the object was recreated or quietly updated in place.

## What the tests do

**Destroy** asks the server for the object by ID and requires a *not-found specifically*. Stricter than listing and matching a name — it also catches a delete that removed the wrong object, and a bare `err != nil` would let an auth failure read as a successful delete. Three helper shapes, because the API is not uniform: `testCheckGone` for a by-ID getter, `testCheckAbsentFromList` for users (no by-ID getter exists), and `testRecordAttr` for objects reached through a parent.

**Import** uses `ImportStateVerify`, which compares imported state against the original attribute by attribute — so any field the read path maps differently on import than on create fails here and nowhere else. Four resources need a composite ID, built from state by `testImportIDFrom`. Six have write-only attributes the server never returns after creation, which are listed in `ImportStateVerifyIgnore` rather than left to fail spuriously.

**Data sources** create a resource and read it back in the same configuration, asserting with `TestCheckResourceAttrPair` so the two must agree attribute by attribute. Stronger than matching literals — it also fails when both sides are wrong in different ways — and it needs no editing when a fixture value changes.

**Replacement** compares the server-assigned ID across a change to a `RequiresReplace` attribute. The user test asserts the opposite direction too: `role` is *not* marked for replacement, so it must keep its ID. Without that pair, a provider that recreated everything would pass the replacement tests just as happily.

**Updates that must not replace** are asserted from the plan rather than after the fact. `Test_SetupKey_Update_Groups_AddRemove` walks the sequence a user actually performs on a setup key — attach a group, attach another, drop one, drop the rest — and each step requires Terraform to have planned an in-place update. A failure names the action Terraform chose and the attributes that forced a replacement, which is the part that has to change to fix it; only the attributes that can force one are reported, so the plaintext key never lands in the log.

**Rejection** feeds one value outside each validator's set and requires the plan to fail. These cost nothing to run — the configuration is refused before anything reaches the server.

## What this found

**Setup keys were recreated whenever anything about them changed.** Reported by a user: adding a group to an existing setup key destroyed it and issued a new secret, leaving every peer still holding the old one unable to register. The group test above reproduces it, and it turned out to be two defects at once — attributes nobody configured being planned as unknown on `RequiresReplace` attributes, and a `usage_limit` default the server refuses to honour for one-off keys. Both are fixed in #201, with the server-side half in netbirdio/netbird#7220.

**`netbird_peer` never deletes anything under the acceptance suite.** `Peer.Delete` skips the API call whenever `TF_ACC` is set:

```go
// Do not delete actual peers in acceptance tests to make running locally easier
if _, ok := os.LookupEnv("TF_ACC"); !ok {
```

So the one path a delete test exercises was switched off exactly when that test ran — no amount of test-writing could have closed it. And the branch is in shipped code, not a test: `TF_ACC` is terraform-plugin-testing's switch, plausibly set in the shell of anyone who develops providers, and any such user got a provider whose `terraform destroy` reported success while the peer stayed registered. `Test_Peer_Delete` reports it; #201 removes the branch.

**`Token.Update` reads its guard before populating it.**

```go
var data TokenModel

if data.Id.ValueString() == "" {     // data is still zero-valued here
	r.Create(...)
	return
}
resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)   // populated only now
resp.Diagnostics.AddError("Invalid Operation", "Personal Access Tokens can't be updated")
```

The condition is always true, so `Update` always calls `Create` and the error below is unreachable. `User.Update` performs the same check in the correct order, which shows the intended shape. Fixed in #201.

**Two attributes cannot survive an import, for different reasons.** `token.expiration_days` is not returned by the API but is exactly recoverable from the two timestamps that are, so #201 recovers it. `setup_key.expiry_seconds` is not recoverable at all — the response has an absolute expiry date and no creation date — so the import step stops comparing it and #201 makes an imported key adopt the configured value rather than being destroyed by the first plan.

**The identity provider issuer is dropped for two of its seven types.** The management server stores `google` and `microsoft` providers as OAuth2 connectors, whose stored config has no issuer field, so the value is validated at creation and then lost. Nothing in the provider can recover it; the data source test uses `oidc` and says why.

**Import IDs are inconsistent.** `dns_record` splits its composite ID on `:` while `network_resource`, `network_router` and `token` split on `/`. That is a user-facing documented format differing across resources for no evident reason. The tests encode today's behaviour; worth a decision later.

**Three parameters existed only for show, and the linter proved it.** `unparam` flagged that `idpType` was always `"oidc"` — while the validator accepts seven values — and that `is_blocked` was never once set to `true`. Rather than delete the parameters, the new tests use a second IdP type and actually toggle blocking, so lint discipline turned into coverage.

## Deliberately not covered

Not an unfinished edge — the reasons differ per group:

- **Data sources** have nothing to destroy.
- **`netbird_account_settings` and `netbird_dns_settings`** keep their values on destroy rather than deleting; **`netbird_agent_network_settings`** releases the account's gateway. "Is it gone" is the wrong question for all three. #202 asserts what each one actually does.
- **Eight tests assert on rejected configurations**, so nothing reaches the server to delete.
- **The SCIM pair skips unconditionally** as cloud-only.
- **Peer create and update** manage agents that later tests address by name.

The agent fixtures are split by purpose for that last reason: `peer1` and `peer2` shared and read-only, `peer3` onwards consumable, one per test that manages a peer through its own lifecycle. One each rather than shared, because sharing would make the later test depend on the order Go compiles files in.

## Still open

Two data sources — agent-network policy and guardrail — whose resource configurations are written inline rather than through a builder, so covering them means extracting those first. And the attribute surface is at 55%, with `posture_check` (3 of 22), `policy` (3 of 18) and `account_settings` (9 of 22) the largest remaining.

#202 takes the rest of it: drift, wrong import IDs, the remaining validators and replacements, and the resource-specific cases.

## Test plan

- `gofmt`, `go vet` and `golangci-lint run`, each with and without `-tags e2e` — all clean.
- `go test ./...` — the untagged suite is unaffected.
- 161 test functions in the tagged binary, up from 131.
- The acceptance run is what proves the new checks fire, and it is expected red on the defects above.