### PR TITLE
[provider] Fix the delete, update and replacement paths the new tests caught

### DIFF
--- a/docs/resources/setup_key.md
+++ b/docs/resources/setup_key.md
@@ -41,10 +41,10 @@ resource "netbird_setup_key" "example" {
 - `allow_extra_dns_labels` (Boolean) Allow extra DNS labels to be added to the peer
 - `auto_groups` (List of String) List of groups to automatically assign to peers created through this setup key
 - `ephemeral` (Boolean) Indicate that the peer will be ephemeral or not, ephemeral peers are deleted after 10 minutes of inactivity
-- `expiry_seconds` (Number) Expiry time in seconds (0 is unlimited)
+- `expiry_seconds` (Number) Expiry time in seconds (0 is unlimited). The API reports an absolute expiry date and no creation date, so this value cannot be read back and an imported key adopts whatever the configuration says.
 - `revoked` (Boolean) Set to true to revoke setup key
 - `type` (String) Setup Key type (one-off or reusable)
-- `usage_limit` (Number) Maximum number of times SetupKey can be used (0 for unlimited)
+- `usage_limit` (Number) Maximum number of times SetupKey can be used (0 for unlimited). A one-off key is always limited to 1 by the server, so leave this unset for one-off keys.
 
 ### Read-Only
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -56,7 +56,7 @@ resource "netbird_user" "real_user" {
 - `is_current` (Boolean) Set to true if the caller user is the same as the resource user
 - `issued` (String) User issue method
 - `last_login` (String) User Last Login timedate
-- `status` (String) User status (active or invited)
+- `status` (String) User status (active, invited or blocked)
 
 ## Import
 

--- a/internal/provider/account_settings_resource.go
+++ b/internal/provider/account_settings_resource.go
@@ -373,7 +373,7 @@ func (r *AccountSettings) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/dns_record_resource.go
+++ b/internal/provider/dns_record_resource.go
@@ -193,7 +193,7 @@ func (r *DNSRecord) Update(ctx context.Context, req resource.UpdateRequest, resp
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/dns_settings_resource.go
+++ b/internal/provider/dns_settings_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -24,7 +23,10 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &DNSSettings{}
-var _ resource.ResourceWithImportState = &DNSSettings{}
+
+// No ResourceWithImportState: the account's DNS settings have no identifier to
+// import by. The schema is a single disabled_management_groups list, with no id
+// attribute, so the passthrough this used to declare could only ever fail.
 
 func NewDNSSettings() resource.Resource {
 	return &DNSSettings{}
@@ -182,8 +184,4 @@ func (r *DNSSettings) Update(ctx context.Context, req resource.UpdateRequest, re
 
 func (r *DNSSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Do nothing
-}
-
-func (r *DNSSettings) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/dns_zone_resource.go
+++ b/internal/provider/dns_zone_resource.go
@@ -210,7 +210,7 @@ func (r *DNSZone) Update(ctx context.Context, req resource.UpdateRequest, resp *
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -224,7 +224,7 @@ func (r *Group) Update(ctx context.Context, req resource.UpdateRequest, resp *re
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/identity_provider_resource.go
+++ b/internal/provider/identity_provider_resource.go
@@ -173,7 +173,7 @@ func (r *IdentityProvider) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	if data.Id.IsNull() || data.Id.IsUnknown() || data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/nameserver_group_resource.go
+++ b/internal/provider/nameserver_group_resource.go
@@ -334,7 +334,7 @@ func (r *NameserverGroup) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/network_resource.go
+++ b/internal/provider/network_resource.go
@@ -201,7 +201,7 @@ func (r *Network) Update(ctx context.Context, req resource.UpdateRequest, resp *
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/network_resource_resource.go
+++ b/internal/provider/network_resource_resource.go
@@ -215,7 +215,7 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/network_router_resource.go
+++ b/internal/provider/network_router_resource.go
@@ -220,7 +220,7 @@ func (r *NetworkRouter) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/peer_resource.go
+++ b/internal/provider/peer_resource.go
@@ -355,7 +355,7 @@ func (r *Peer) Update(ctx context.Context, req resource.UpdateRequest, resp *res
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/peer_resource.go
+++ b/internal/provider/peer_resource.go
@@ -6,7 +6,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -400,12 +399,8 @@ func (r *Peer) Delete(ctx context.Context, req resource.DeleteRequest, resp *res
 		return
 	}
 
-	// Do not delete actual peers in acceptance tests to make running locally easier
-	if _, ok := os.LookupEnv("TF_ACC"); !ok {
-		err := r.client.Peers.Delete(ctx, data.Id.ValueString())
-		if err != nil {
-			resp.Diagnostics.AddError("Error deleting Peer", err.Error())
-		}
+	if err := r.client.Peers.Delete(ctx, data.Id.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting Peer", err.Error())
 	}
 }
 

--- a/internal/provider/posture_check_resource.go
+++ b/internal/provider/posture_check_resource.go
@@ -617,7 +617,7 @@ func (r *PostureCheck) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/route_resource.go
+++ b/internal/provider/route_resource.go
@@ -305,7 +305,7 @@ func (r *Route) Update(ctx context.Context, req resource.UpdateRequest, resp *re
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/scim_resource.go
+++ b/internal/provider/scim_resource.go
@@ -70,7 +70,10 @@ func (r *Scim) Schema(ctx context.Context, req resource.SchemaRequest, resp *res
 				MarkdownDescription: "The connection prefix used for the SCIM provider.",
 				Optional:            true,
 				Computed:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"enabled": schema.BoolAttribute{
 				MarkdownDescription: "Indicates whether the integration is enabled",

--- a/internal/provider/setup_key_plan_test.go
+++ b/internal/provider/setup_key_plan_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// object is the shape of a raw state or plan value. Only its null-ness is read
+// by the modifier, so one attribute is enough to make it a value rather than
+// nothing.
+var rawObject = tftypes.Object{AttributeTypes: map[string]tftypes.Type{"id": tftypes.String}}
+
+func rawNull() tftypes.Value { return tftypes.NewValue(rawObject, nil) }
+func rawKnown() tftypes.Value {
+	return tftypes.NewValue(rawObject, map[string]tftypes.Value{"id": tftypes.NewValue(tftypes.String, "k1")})
+}
+
+func Test_expirySecondsPlanModifier(t *testing.T) {
+	cases := []struct {
+		name        string
+		state, plan tftypes.Value
+		stateValue  types.Int32
+		planValue   types.Int32
+		wantReplace bool
+	}{
+		{
+			name:  "creating",
+			state: rawNull(), plan: rawKnown(),
+			stateValue: types.Int32Null(), planValue: types.Int32Value(1800),
+		},
+		{
+			name:  "destroying",
+			state: rawKnown(), plan: rawNull(),
+			stateValue: types.Int32Value(1800), planValue: types.Int32Null(),
+		},
+		{
+			// The import case: the API never reported the value, so state has
+			// none. Replacing here would destroy the key that was just adopted.
+			name:  "adopting an imported key",
+			state: rawKnown(), plan: rawKnown(),
+			stateValue: types.Int32Null(), planValue: types.Int32Value(1800),
+		},
+		{
+			name:  "unchanged",
+			state: rawKnown(), plan: rawKnown(),
+			stateValue: types.Int32Value(1800), planValue: types.Int32Value(1800),
+		},
+		{
+			// The server cannot move an expiry date, so this is a new key.
+			name:  "changed",
+			state: rawKnown(), plan: rawKnown(),
+			stateValue: types.Int32Value(1800), planValue: types.Int32Value(3600),
+			wantReplace: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp := &planmodifier.Int32Response{PlanValue: c.planValue}
+			expirySecondsPlanModifier{}.PlanModifyInt32(context.Background(), planmodifier.Int32Request{
+				State:      tfsdk.State{Raw: c.state},
+				Plan:       tfsdk.Plan{Raw: c.plan},
+				StateValue: c.stateValue,
+				PlanValue:  c.planValue,
+			}, resp)
+
+			if resp.RequiresReplace != c.wantReplace {
+				t.Errorf("RequiresReplace = %v, want %v", resp.RequiresReplace, c.wantReplace)
+			}
+		})
+	}
+}

--- a/internal/provider/setup_key_resource.go
+++ b/internal/provider/setup_key_resource.go
@@ -380,7 +380,7 @@ func (r *SetupKey) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/setup_key_resource.go
+++ b/internal/provider/setup_key_resource.go
@@ -122,7 +122,10 @@ func (r *SetupKey) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				MarkdownDescription: "Maximum number of times SetupKey can be used (0 for unlimited). A one-off key is always limited to 1 by the server, so leave this unset for one-off keys.",
 				Computed:            true,
 				Optional:            true,
-				PlanModifiers:       []planmodifier.Int32{int32planmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.UseStateForUnknown(),
+					int32planmodifier.RequiresReplace(),
+				},
 			},
 			"used_times": schema.Int32Attribute{
 				MarkdownDescription: "Number of times Setup Key was used",
@@ -145,13 +148,19 @@ func (r *SetupKey) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				MarkdownDescription: "Indicate that the peer will be ephemeral or not, ephemeral peers are deleted after 10 minutes of inactivity",
 				Computed:            true,
 				Optional:            true,
-				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 			"allow_extra_dns_labels": schema.BoolAttribute{
 				MarkdownDescription: "Allow extra DNS labels to be added to the peer",
 				Computed:            true,
 				Optional:            true,
-				PlanModifiers:       []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 			"valid": schema.BoolAttribute{
 				MarkdownDescription: "True if setup key can be used to create more Peers",

--- a/internal/provider/setup_key_resource.go
+++ b/internal/provider/setup_key_resource.go
@@ -32,6 +32,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &SetupKey{}
 var _ resource.ResourceWithImportState = &SetupKey{}
+var _ resource.ResourceWithValidateConfig = &SetupKey{}
 
 func NewSetupKey() resource.Resource {
 	return &SetupKey{}
@@ -88,11 +89,11 @@ func (r *SetupKey) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				Computed:            true,
 			},
 			"expiry_seconds": schema.Int32Attribute{
-				MarkdownDescription: "Expiry time in seconds (0 is unlimited)",
+				MarkdownDescription: "Expiry time in seconds (0 is unlimited). The API reports an absolute expiry date and no creation date, so this value cannot be read back and an imported key adopts whatever the configuration says.",
 				Optional:            true,
 				Computed:            true,
 				Default:             int32default.StaticInt32(0),
-				PlanModifiers:       []planmodifier.Int32{int32planmodifier.RequiresReplace()},
+				PlanModifiers:       []planmodifier.Int32{expirySecondsPlanModifier{}},
 			},
 			"updated_at": schema.StringAttribute{
 				MarkdownDescription: "Creation timestamp",
@@ -118,11 +119,10 @@ func (r *SetupKey) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				Validators:          []validator.String{stringvalidator.OneOf("one-off", "reusable")},
 			},
 			"usage_limit": schema.Int32Attribute{
-				MarkdownDescription: "Maximum number of times SetupKey can be used (0 for unlimited)",
+				MarkdownDescription: "Maximum number of times SetupKey can be used (0 for unlimited). A one-off key is always limited to 1 by the server, so leave this unset for one-off keys.",
 				Computed:            true,
 				Optional:            true,
 				PlanModifiers:       []planmodifier.Int32{int32planmodifier.RequiresReplace()},
-				Default:             int32default.StaticInt32(0),
 			},
 			"used_times": schema.Int32Attribute{
 				MarkdownDescription: "Number of times Setup Key was used",
@@ -165,6 +165,74 @@ func (r *SetupKey) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 			},
 		},
 	}
+}
+
+// expirySecondsPlanModifier replaces the setup key when its configured lifetime
+// changes, except when there is no prior value to compare against.
+//
+// The API has no field for the lifetime a key was created with. It reports an
+// absolute expiry date and no creation date, so nothing can be measured back
+// out of a read, and a key that was imported rather than created has no value
+// for it in state. Reading that absence as a change is what plain
+// RequiresReplace does, and it would destroy the key the user has just imported
+// and hand back a different secret. The configured value is adopted instead,
+// which costs one no-op update. A change between two known values still
+// replaces, because the server cannot move an expiry date.
+type expirySecondsPlanModifier struct{}
+
+func (expirySecondsPlanModifier) Description(context.Context) string {
+	return "Replaces the setup key when the configured expiry changes, and adopts the configured value when state has none."
+}
+
+func (m expirySecondsPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (expirySecondsPlanModifier) PlanModifyInt32(ctx context.Context, req planmodifier.Int32Request, resp *planmodifier.Int32Response) {
+	// Creating or destroying: there is no prior value that could have changed.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+	// Imported, so never recorded: take the planned value as it stands.
+	if req.StateValue.IsNull() {
+		return
+	}
+	if !req.PlanValue.Equal(req.StateValue) {
+		resp.RequiresReplace = true
+	}
+}
+
+// ValidateConfig rejects a usage limit a one-off key cannot honour. The server
+// pins a one-off key at a single use and ignores what the request asked for, so
+// a configuration naming anything else describes a key that will never exist.
+// Left alone, that surfaces at apply time as "Provider produced inconsistent
+// result after apply", which does not say what to change, and it leaves the
+// difference in state where it later forces the key to be recreated.
+func (r *SetupKey) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data SetupKeyModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.UsageLimit.IsNull() || data.UsageLimit.IsUnknown() || data.Type.IsUnknown() {
+		return
+	}
+	// An absent type is one-off, which is the schema default and is filled in
+	// after this runs.
+	if !data.Type.IsNull() && data.Type.ValueString() != "one-off" {
+		return
+	}
+	if data.UsageLimit.ValueInt32() == 1 {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("usage_limit"),
+		"Invalid Attribute Combination",
+		`A one-off setup key can be used once, and the server fixes its usage limit at 1 whatever the request asks for. Remove usage_limit, set it to 1, or set type to "reusable".`,
+	)
 }
 
 func (r *SetupKey) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -127,11 +128,30 @@ func (r *Token) Configure(ctx context.Context, req resource.ConfigureRequest, re
 	r.client = client
 }
 
+// tokenExpirationDays recovers the lifetime a token was created with. The API
+// does not report it, but it reports both timestamps it was derived from: the
+// server sets the expiry to the creation time plus a whole number of days, in
+// UTC, where every day is 24 hours long. Rounding absorbs whatever sub-second
+// difference survives storage and transport.
+func tokenExpirationDays(createdAt, expirationDate time.Time) int32 {
+	return int32(math.Round(expirationDate.Sub(createdAt).Hours() / 24))
+}
+
 func tokenAPIToTerraform(token *api.PersonalAccessToken, data *TokenModel) {
 	data.Id = types.StringValue(token.Id)
 	data.Name = types.StringValue(token.Name)
 	data.ExpirationDate = types.StringValue(token.ExpirationDate.Format(time.RFC3339))
 	data.CreatedAt = types.StringValue(token.CreatedAt.Format(time.RFC3339))
+	// expiration_days is required, so it is already known everywhere except
+	// after an import, where nothing but the two timestamps is available to
+	// reconstruct it. Without this the imported token is missing an attribute
+	// its configuration requires, and the first plan after the import destroys
+	// and recreates it.
+	if data.ExpirationDays.IsNull() {
+		if days := tokenExpirationDays(token.CreatedAt, token.ExpirationDate); days > 0 {
+			data.ExpirationDays = types.Int32Value(days)
+		}
+	}
 	if token.LastUsed == nil {
 		data.LastUsed = types.StringNull()
 	} else {

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -206,12 +206,21 @@ func (r *Token) Read(ctx context.Context, req resource.ReadRequest, resp *resour
 func (r *Token) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data TokenModel
 
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The guard has to come after the plan is read. Checking data.Id on a
+	// zero-valued model made the condition always true, so this always called
+	// Create and the error below was unreachable.
 	if data.Id.ValueString() == "" {
 		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
 		return
 	}
-	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
 	resp.Diagnostics.AddError("Invalid Operation", "Personal Access Tokens can't be updated")
 }
 

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -237,7 +237,7 @@ func (r *Token) Update(ctx context.Context, req resource.UpdateRequest, resp *re
 	// zero-valued model made the condition always true, so this always called
 	// Create and the error below was unreachable.
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 

--- a/internal/provider/token_test.go
+++ b/internal/provider/token_test.go
@@ -13,10 +13,13 @@ func Test_tokenAPIToTerraform(t *testing.T) {
 	timeNow := time.Now()
 
 	cases := []struct {
+		name     string
 		resource *api.PersonalAccessToken
+		in       TokenModel
 		expected TokenModel
 	}{
 		{
+			name: "maps the response",
 			resource: &api.PersonalAccessToken{
 				Id:             "r1",
 				CreatedAt:      timeNow,
@@ -33,14 +36,76 @@ func Test_tokenAPIToTerraform(t *testing.T) {
 				LastUsed:       types.StringValue(timeNow.Format(time.RFC3339)),
 			},
 		},
+		{
+			// The import case: nothing but the two timestamps to work from.
+			name: "recovers the lifetime when state has none",
+			resource: &api.PersonalAccessToken{
+				Id:             "r2",
+				CreatedAt:      timeNow,
+				ExpirationDate: timeNow.AddDate(0, 0, 180),
+				Name:           "test",
+			},
+			expected: TokenModel{
+				Id:             types.StringValue("r2"),
+				UserID:         types.StringNull(),
+				Name:           types.StringValue("test"),
+				CreatedAt:      types.StringValue(timeNow.Format(time.RFC3339)),
+				ExpirationDate: types.StringValue(timeNow.AddDate(0, 0, 180).Format(time.RFC3339)),
+				ExpirationDays: types.Int32Value(180),
+				LastUsed:       types.StringNull(),
+			},
+		},
+		{
+			// A configured lifetime is what the user asked for, and it is the
+			// value the token was created with. Recomputing it from timestamps
+			// could only introduce a difference, and a difference on this
+			// attribute recreates the token.
+			name: "leaves a known lifetime alone",
+			resource: &api.PersonalAccessToken{
+				Id:             "r3",
+				CreatedAt:      timeNow,
+				ExpirationDate: timeNow.AddDate(0, 0, 180),
+				Name:           "test",
+			},
+			in: TokenModel{ExpirationDays: types.Int32Value(30)},
+			expected: TokenModel{
+				Id:             types.StringValue("r3"),
+				UserID:         types.StringNull(),
+				Name:           types.StringValue("test"),
+				CreatedAt:      types.StringValue(timeNow.Format(time.RFC3339)),
+				ExpirationDate: types.StringValue(timeNow.AddDate(0, 0, 180).Format(time.RFC3339)),
+				ExpirationDays: types.Int32Value(30),
+				LastUsed:       types.StringNull(),
+			},
+		},
 	}
 
 	for _, c := range cases {
-		var out TokenModel
-		tokenAPIToTerraform(c.resource, &out)
+		t.Run(c.name, func(t *testing.T) {
+			out := c.in
+			tokenAPIToTerraform(c.resource, &out)
 
-		if !reflect.DeepEqual(out, c.expected) {
-			t.Fatalf("Expected:\n%#v\nFound:\n%#v", c.expected, out)
+			if !reflect.DeepEqual(out, c.expected) {
+				t.Fatalf("Expected:\n%#v\nFound:\n%#v", c.expected, out)
+			}
+		})
+	}
+}
+
+func Test_tokenExpirationDays(t *testing.T) {
+	// AddDate is how the server derives the expiry, and it is called on a UTC
+	// timestamp, where a calendar day and 24 hours are the same span.
+	created := time.Date(2026, 3, 8, 23, 30, 0, 0, time.UTC)
+	for _, days := range []int{1, 30, 180, 365} {
+		if got := tokenExpirationDays(created, created.AddDate(0, 0, days)); got != int32(days) {
+			t.Errorf("expected %d days, got %d", days, got)
 		}
+	}
+
+	// Whatever a round trip through storage and JSON does to the sub-second
+	// part, it must not change the number of days.
+	drifted := created.AddDate(0, 0, 90).Add(-400 * time.Millisecond)
+	if got := tokenExpirationDays(created, drifted); got != 90 {
+		t.Errorf("expected 90 days despite drift, got %d", got)
 	}
 }

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -96,9 +96,13 @@ func (r *User) Schema(ctx context.Context, req resource.SchemaRequest, resp *res
 				Validators:          []validator.String{stringvalidator.OneOf("owner", "admin", "user", "billing_admin", "auditor", "network_admin")},
 			},
 			"status": schema.StringAttribute{
-				MarkdownDescription: "User status (active or invited)",
+				// No UseStateForUnknown: status tracks is_blocked, so keeping the
+				// prior value through the plan made Terraform expect "active" while
+				// the apply returned "blocked", which it reports as the provider
+				// producing an inconsistent result. It has to be planned as unknown
+				// because it is a value only the server can supply.
+				MarkdownDescription: "User status (active, invited or blocked)",
 				Computed:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"issued": schema.StringAttribute{
 				MarkdownDescription: "User issue method",

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -252,7 +252,7 @@ func (r *User) Update(ctx context.Context, req resource.UpdateRequest, resp *res
 	}
 
 	if data.Id.ValueString() == "" {
-		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.Config}, (*resource.CreateResponse)(resp))
+		r.Create(ctx, resource.CreateRequest{Config: req.Config, Plan: req.Plan, ProviderMeta: req.ProviderMeta}, (*resource.CreateResponse)(resp))
 		return
 	}
 


### PR DESCRIPTION
Fourth of five. Stacked on #200 — review that first; this diff is against it, and it is what turns #200 green.

Everything here is a change to provider behaviour. The test-side arrangement that goes with it lives in #200, so this PR is only the business logic.

## Setup keys were recreated whenever anything about them changed

Reported by a user: adding a group to an existing setup key destroyed the key and issued a new one. A setup key is a secret, so a recreated key leaves every peer still holding the old one unable to register. Two independent defects produced it.

**Attributes nobody configured were planned as unknown.** `usage_limit`, `ephemeral` and `allow_extra_dns_labels` are Optional, Computed and `RequiresReplace`. When such an attribute is absent from the configuration, the framework plans it as unknown on any update; unknown is not equal to what is in state, so `RequiresReplace` fires — on a change that had nothing to do with it. Any update to a setup key whose configuration did not spell out all three recreated the key. `UseStateForUnknown` ahead of `RequiresReplace` fixes it: an attribute nobody configured keeps the value the server gave it, while a configured value that changes still replaces.

`scim.prefix` had the same combination and gets the same treatment. It is the only other attribute in the provider that did — the whole schema was checked rather than sampled.

**`usage_limit` defaulted to a value the server refuses to honour.** The server pins a one-off key at a single use whatever the request asks for, so a key created with the schema's default of `0` came back as `1`, and every plan after that saw a difference on a replace-forcing attribute. The default is gone: unset now means unknown, which is what an attribute the server decides should be, and the server's answer is accepted rather than contradicted. A configuration that *does* name a usage limit for a one-off key is now rejected during validation, where the message can say what to change — previously it failed at apply time with "Provider produced inconsistent result after apply". The server-side half of that is netbirdio/netbird#7220.

## Importing a setup key or a token destroyed it on the next apply

Neither resource could describe itself fully from a read, and both paid for it at the first plan after an import.

**`token.expiration_days`** is not returned by the API, but both timestamps it is derived from are: the server sets the expiry to the creation time plus a whole number of days, in UTC, where a day is always 24 hours. Dividing and rounding recovers exactly what was asked for. The value is filled in only when state has none — that is the import path — because recomputing it on every read could only introduce a difference against what the user configured, and a difference there recreates the token.

**`setup_key.expiry_seconds`** cannot be recovered at all: the response carries an absolute expiry date and no creation date, so there is nothing to measure back out of it, and an imported key has no value for it. Plain `RequiresReplace` reads that absence as a change and destroys the key that was just adopted, so a small plan modifier adopts the configured value instead, at the cost of one no-op update. A change between two known values still replaces, because the server cannot move an expiry date.

## Blocking a user made the provider look buggy

```
When applying changes to netbird_user.x, provider produced an unexpected new value:
.status: was cty.StringVal("active"), but now cty.StringVal("blocked").
```

`status` carried `UseStateForUnknown`, which keeps the value already in state through the plan. That is right for an attribute the server never changes on its own, and wrong here: `status` tracks `is_blocked`, so the plan promised "active" while the apply returned "blocked". Removing the modifier lets it plan as unknown, which is what a value only the server can supply should be.

## DNS settings advertised an import that could not work

`netbird_dns_settings` implemented `ImportState` by writing the import ID into `id`. The resource is an account-wide singleton with no `id` attribute, so every import failed with an error naming an attribute that does not exist. The interface declaration goes with it; the resource is created and read the same way as before.

## Peers were never deleted under the acceptance suite

```go
// Do not delete actual peers in acceptance tests to make running locally easier
if _, ok := os.LookupEnv("TF_ACC"); !ok {
	err := r.client.Peers.Delete(ctx, data.Id.ValueString())
```

Two separate problems, and the second is the serious one.

**The suite could not cover peer deletion.** The one code path a delete test exercises was switched off exactly when that test ran. No amount of test-writing could have closed that gap; `Test_Peer_Delete` in #200 is what reports it.

**It is shipped code branching on a test variable.** `TF_ACC` is not a NetBird setting — it is terraform-plugin-testing's switch, and it is plausibly set in the shell of anyone who develops Terraform providers. Any such user got a provider whose `terraform destroy` reported success while the peer stayed registered. Deleting the branch is the fix, and it removes the only place where provider behaviour depended on a test variable — the remaining `os.LookupEnv` calls are provider configuration (`NB_MANAGEMENT_URL`, `NB_PAT`, `NB_ACCOUNT`), which was checked rather than assumed.

## Token.Update checked a value it had not read yet

```go
var data TokenModel

if data.Id.ValueString() == "" {     // data is still the zero value here
	r.Create(...)
	return
}
resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)   // populated only now
resp.Diagnostics.AddError("Invalid Operation", "Personal Access Tokens can't be updated")
```

`data` is declared and then tested before `req.Plan.Get` fills it, so `data.Id` is always empty, the branch is always taken, and `Update` always calls `Create`. The error that says tokens cannot be updated is unreachable. `User.Update` does the same check *after* reading the plan, which is the intended shape; this reorders the token version to match.

The blast radius is small today — every token attribute is `RequiresReplace`, so Terraform destroys and recreates rather than calling `Update` — but "unreachable because of a second, unrelated declaration" is not a property worth relying on.

## Provider metadata was the resource configuration

Fifteen resources delegate `Update` to `Create` when the object has no ID, and every one passed `req.Config` as the delegated call's `ProviderMeta`. Those are different things. Nothing observable changes today, because the provider declares no `provider_meta` schema and the value is empty either way — it stops being true the moment one is added, which is exactly when it would be hard to find. All fifteen are corrected rather than only the one CodeRabbit spotted, since the line is identical in each.

## What this does not change

The **import ID separator inconsistency** #200 documents — `dns_record` splits on `:` while `network_resource`, `network_router` and `token` split on `/` — is left alone. It is a documented user-facing format, so changing it breaks anyone scripting imports today, and choosing which way to converge is a maintainer's call rather than a drive-by fix.

The **identity provider issuer** is dropped by the server for the `google` and `microsoft` types, which store their connectors without an issuer field. Nothing in the provider can recover it; #200's data source test avoids those two types and says why.

**Setting an email on a service user** still fails the apply. The server drops the address and returns an empty one, and Terraform reports it as the provider contradicting its own plan — the same shape as the `usage_limit` defect above, and it wants the same fix: refused during validation with a message that says why. #202 found it while writing the user replacement case; it is not fixed here because it arrived after this PR was green, and it deserves its own change rather than an amendment to this one.

## Test plan

- `gofmt`, `go vet` and `golangci-lint run`, each with and without `-tags e2e` — all clean.
- `go test ./...` — the untagged suite passes, and now covers the token lifetime recovery and the `expiry_seconds` plan modifier, including its import case.
- `make generate` — docs regenerated for the descriptions that changed.
- The setup key replacement was reproduced and then confirmed fixed against a stub API before it went near CI: the plan for adding a group went from `delete create`, with `ephemeral`, `usage_limit` and `allow_extra_dns_labels` in its replace paths, to a plain `update` with none.
- CI is green here, including the acceptance suite. The checks that matter are `Test_SetupKey_Update_Groups_AddRemove`, `Test_SetupKey_Replaced`, `Test_SetupKey_Create`, `Test_Token_Create`, `Test_User_Replaced` and `Test_Peer_Delete`, all of which fail on #200 and pass here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation preventing one-off setup keys from using usage limits other than 1.
  * Improved preservation and replacement handling for setup key settings and SCIM prefixes.
  * Reconstructed token expiration periods during import when needed.
  * Added support for the `blocked` user status.

* **Bug Fixes**
  * Improved resource creation, updates, deletion, and imports for more reliable API synchronization.

* **Documentation**
  * Clarified setup key expiry and usage-limit behavior.
  * Documented `blocked` as a supported user status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->