### PR TITLE
[tests] Automate the lifecycle cases nobody was running

### DIFF
--- a/internal/provider/agent_network_acc_test.go
+++ b/internal/provider/agent_network_acc_test.go
@@ -120,6 +120,44 @@ func testAgentNetworkProviderResource(rName, name, extraValues, metadataDisabled
 }`, rName, name, extraValues, metadataDisabled)
 }
 
+// testAgentNetworkGuardrailResource and testAgentNetworkPolicyResource are the
+// minimum a guardrail and a policy need to exist, for tests whose subject is
+// something else — a data source read, for instance.
+func testAgentNetworkGuardrailResource(rName string) string {
+	return fmt.Sprintf(`resource "netbird_agent_network_guardrail" "%[1]s" {
+	name        = "%[1]s"
+	description = "acceptance test"
+	model_allowlist = {
+		enabled = true
+		models  = ["gpt-4.1"]
+	}
+	prompt_capture = {
+		enabled    = true
+		redact_pii = true
+	}
+}
+`, rName)
+}
+
+func testAgentNetworkPolicyResource(rName string) string {
+	return testAgentNetworkProviderResource(rName, rName+"-provider", `null`, "false") + "\n" +
+		testAgentNetworkGuardrailResource(rName) + fmt.Sprintf(`
+resource "netbird_agent_network_policy" "%[1]s" {
+	name                     = "%[1]s"
+	description              = "acceptance test"
+	source_groups            = [%[2]q]
+	destination_provider_ids = [netbird_agent_network_provider.%[1]s.id]
+	guardrail_ids            = [netbird_agent_network_guardrail.%[1]s.id]
+
+	token_limit = {
+		enabled        = true
+		group_cap      = 1000000
+		window_seconds = 86400
+	}
+}
+`, rName, e2eGroupNotAllID())
+}
+
 func Test_AgentNetworkProvider_Create(t *testing.T) {
 	testE2E(t)
 	rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)

--- a/internal/provider/data_source_acc_test.go
+++ b/internal/provider/data_source_acc_test.go
@@ -237,6 +237,24 @@ func Test_AgentNetworkProvider_DataSource(t *testing.T) {
 		samePair("agent_network_provider", rName, "name", "enabled"))
 }
 
+func Test_AgentNetworkGuardrail_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "ang" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	dsCase(t, testAgentNetworkGuardrailResource(rName)+dataSourceByID("agent_network_guardrail", rName),
+		samePair("agent_network_guardrail", rName, "name", "description",
+			"model_allowlist.enabled", "model_allowlist.models.#",
+			"prompt_capture.enabled", "prompt_capture.redact_pii"))
+}
+
+func Test_AgentNetworkPolicy_DataSource(t *testing.T) {
+	testE2E(t)
+	rName := "anpol" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	dsCase(t, testAgentNetworkPolicyResource(rName)+dataSourceByID("agent_network_policy", rName),
+		samePair("agent_network_policy", rName, "name", "description", "enabled",
+			"source_groups.#", "destination_provider_ids.#", "guardrail_ids.#",
+			"token_limit.enabled", "token_limit.group_cap", "token_limit.window_seconds"))
+}
+
 func Test_Scim_DataSource(t *testing.T) {
 	// Skipped for the same reason as the SCIM resource tests: the integration is
 	// cloud-only, so a self-hosted deployment has nothing to read.

--- a/internal/provider/data_source_selector_acc_test.go
+++ b/internal/provider/data_source_selector_acc_test.go
@@ -515,8 +515,13 @@ data "netbird_setup_key" "d" {
   name = "%[1]s-not-the-name"
 }
 `, rName)},
+		// description is set deliberately: leaving it out fails the apply
+		// outright, because the attribute is Optional without being Computed and
+		// the API answers with an empty string rather than nothing. That is a
+		// defect of its own, not this case's subject.
 		{"posture_check", fmt.Sprintf(`resource "netbird_posture_check" "%[1]s" {
-  name = "%[1]s"
+  name        = "%[1]s"
+  description = "selector test"
 
   netbird_version_check {
     min_version = "0.40.0"

--- a/internal/provider/data_source_selector_acc_test.go
+++ b/internal/provider/data_source_selector_acc_test.go
@@ -35,6 +35,11 @@ import (
 // one of" — which is worth matching loosely rather than pinning.
 var noSelector = regexp.MustCompile(`(?s)No selector|at least one of`)
 
+// noMatch is the refusal when a filter is well formed and answers nothing. The
+// wording splits the same way — "matching parameters not found" against
+// "matched the given filters" — so both are accepted.
+var noMatch = regexp.MustCompile(`(?s)No [Mm]atch|not found|matched the given filters`)
+
 // ambiguous is what a filter matching more than one object has to produce.
 var ambiguous = regexp.MustCompile(`(?s)Multiple Matches|match(ed)? more than one|cannot match multiple`)
 
@@ -206,6 +211,89 @@ data "netbird_token" "nothing" {
   user_id = %q
 }
 `, mustE2E().UserID), noSelector)
+	})
+}
+
+// Test_DataSource_RejectsNoMatch asks for a name nothing carries. The answer
+// has to be an error naming the failure, not an empty object: a data source that
+// returns zeros for a name the user misspelled hands those zeros to whatever
+// referenced it.
+func Test_DataSource_RejectsNoMatch(t *testing.T) {
+	testE2E(t)
+
+	// identity_provider and scim are left out: their list endpoints are
+	// cloud-only, so a self-hosted deployment answers with an error about the
+	// integration rather than about the filter.
+	for _, kind := range []string{
+		"group", "network", "setup_key", "user", "posture_check",
+		"nameserver_group", "policy",
+		"agent_network_provider", "agent_network_policy", "agent_network_guardrail",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			rejects(t, fmt.Sprintf(`
+data "netbird_%s" "missing" {
+  name = "does-not-exist-%s"
+}
+`, kind, acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)), noMatch)
+		})
+	}
+
+	// A route is selected by network_id rather than name.
+	t.Run("route", func(t *testing.T) {
+		rejects(t, fmt.Sprintf(`
+data "netbird_route" "missing" {
+  network_id = "does-not-exist-%s"
+}
+`, acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)), noMatch)
+	})
+}
+
+// Test_DataSource_RejectsDisagreeingSelectors gives two selectors that point at
+// different objects. Both are satisfiable on their own, which is what makes this
+// worth a test: a data source that took the first one and ignored the second
+// would return an object the configuration did not ask for.
+func Test_DataSource_RejectsDisagreeingSelectors(t *testing.T) {
+	testE2E(t)
+
+	t.Run("group id and name", func(t *testing.T) {
+		rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		rejects(t, testGroupResource(rName, `[]`)+fmt.Sprintf(`
+data "netbird_group" "%[1]s" {
+  id   = netbird_group.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName), noMatch)
+	})
+
+	t.Run("user id and email", func(t *testing.T) {
+		rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		rejects(t, fmt.Sprintf(`
+resource "netbird_user" "%[1]s" {
+  name            = "%[1]s"
+  email           = "%[1]s@example.com"
+  is_service_user = false
+  role            = "user"
+  auto_groups     = []
+}
+
+data "netbird_user" "%[1]s" {
+  id    = netbird_user.%[1]s.id
+  email = "%[1]s-other@example.com"
+}
+`, rName), noMatch)
+	})
+
+	// The agent network data sources take a different path for a known ID: they
+	// fetch it directly rather than listing, and check the name afterwards. That
+	// is a separate comparison and needs its own case.
+	t.Run("agent network policy id and name", func(t *testing.T) {
+		rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		rejects(t, testAgentNetworkPolicyResource(rName)+fmt.Sprintf(`
+data "netbird_agent_network_policy" "%[1]s" {
+  id   = netbird_agent_network_policy.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName), noMatch)
 	})
 }
 

--- a/internal/provider/data_source_selector_acc_test.go
+++ b/internal/provider/data_source_selector_acc_test.go
@@ -152,6 +152,58 @@ data "netbird_policy" "%[1]s" {
 		dsCase(t, cfg, samePair("policy", rName, "id", "name", "enabled"))
 	})
 
+	t.Run("network resource by name", func(t *testing.T) {
+		// The parent is required either way, so the selector under test is the
+		// name within it rather than the pair.
+		rName := "nr" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testNetworkResourceResource(rName, e2eNetworkID(), "example.com",
+			fmt.Sprintf("[%q]", e2eGroupNotAllID()), rName) + fmt.Sprintf(`
+data "netbird_network_resource" "%[1]s" {
+  network_id = %[2]q
+  name       = netbird_network_resource.%[1]s.name
+}
+`, rName, e2eNetworkID())
+		dsCase(t, cfg, samePair("network_resource", rName, "id", "name", "address"))
+	})
+
+	t.Run("token by name", func(t *testing.T) {
+		rName := "t" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		userID := mustE2E().UserID
+		cfg := testTokenResource(rName, userID, `90`) + fmt.Sprintf(`
+data "netbird_token" "%[1]s" {
+  user_id = %[2]q
+  name    = netbird_token.%[1]s.name
+}
+`, rName, userID)
+		dsCase(t, cfg, samePair("token", rName, "id", "name", "user_id"))
+	})
+
+	t.Run("peer by name", func(t *testing.T) {
+		// A peer is registered by an agent rather than created by Terraform, so
+		// this reads a fixture by the hostname it registered under.
+		name := "peer1"
+		id := testPeerID(t, name)
+		dsCase(t, fmt.Sprintf(`
+data "netbird_peer" "byname" {
+  name = %q
+}
+`, name), resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("data.netbird_peer.byname", "id", id),
+			resource.TestCheckResourceAttr("data.netbird_peer.byname", "name", name),
+			resource.TestCheckResourceAttrSet("data.netbird_peer.byname", "ip"),
+		))
+	})
+
+	t.Run("agent network provider by name", func(t *testing.T) {
+		rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testAgentNetworkProviderResource(rName, rName, `null`, "false") + fmt.Sprintf(`
+data "netbird_agent_network_provider" "%[1]s" {
+  name = netbird_agent_network_provider.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("agent_network_provider", rName, "id", "name", "enabled"))
+	})
+
 	t.Run("agent network guardrail by name", func(t *testing.T) {
 		rName := "ang" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 		cfg := testAgentNetworkGuardrailResource(rName) + fmt.Sprintf(`

--- a/internal/provider/data_source_selector_acc_test.go
+++ b/internal/provider/data_source_selector_acc_test.go
@@ -409,3 +409,313 @@ resource "netbird_setup_key" "%[1]sb" {
 		},
 	})
 }
+
+// Test_DataSource_RejectsNoSelectorWithoutAGuard is the other half of the
+// no-selector story.
+//
+// Five data sources have no explicit guard: they list and filter, and a
+// configuration that names nothing matches nothing, so the answer is the
+// not-found error rather than a message naming the selectors. The outcome is
+// safe either way — no object is returned — but the message is worse, and a
+// test that pins it is how anyone notices if that changes.
+//
+// The reverse proxy pair is left out: their lists need a running cluster.
+func Test_DataSource_RejectsNoSelectorWithoutAGuard(t *testing.T) {
+	testE2E(t)
+
+	t.Run("dns_zone", func(t *testing.T) {
+		rejects(t, "data \"netbird_dns_zone\" \"nothing\" {}\n", noMatch)
+	})
+
+	t.Run("peer", func(t *testing.T) {
+		rejects(t, "data \"netbird_peer\" \"nothing\" {}\n", noMatch)
+	})
+
+	t.Run("dns_record", func(t *testing.T) {
+		rName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		rejects(t, testDNSZoneResource(rName, rName+".local", true, false,
+			fmt.Sprintf("[%q]", e2eGroupNotAllID()))+fmt.Sprintf(`
+data "netbird_dns_record" "nothing" {
+  zone_id = netbird_dns_zone.%s.id
+}
+`, rName), noMatch)
+	})
+}
+
+// Test_DataSource_RejectsNoMatchOnTheRest covers the data sources whose
+// not-found path needs a parent or a fixture, so they do not fit the table in
+// Test_DataSource_RejectsNoMatch.
+func Test_DataSource_RejectsNoMatchOnTheRest(t *testing.T) {
+	testE2E(t)
+	gone := "does-not-exist-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)
+
+	t.Run("dns_zone", func(t *testing.T) {
+		rejects(t, fmt.Sprintf("data \"netbird_dns_zone\" \"missing\" {\n  name = %q\n}\n", gone), noMatch)
+	})
+
+	t.Run("peer", func(t *testing.T) {
+		rejects(t, fmt.Sprintf("data \"netbird_peer\" \"missing\" {\n  name = %q\n}\n", gone), noMatch)
+	})
+
+	t.Run("dns_record", func(t *testing.T) {
+		rName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		rejects(t, testDNSZoneResource(rName, rName+".local", true, false,
+			fmt.Sprintf("[%q]", e2eGroupNotAllID()))+fmt.Sprintf(`
+data "netbird_dns_record" "missing" {
+  zone_id = netbird_dns_zone.%s.id
+  name    = %q
+}
+`, rName, gone), noMatch)
+	})
+
+	t.Run("network_resource", func(t *testing.T) {
+		rejects(t, fmt.Sprintf(`
+data "netbird_network_resource" "missing" {
+  network_id = %q
+  name       = %q
+}
+`, e2eNetworkID(), gone), noMatch)
+	})
+
+	t.Run("token", func(t *testing.T) {
+		rejects(t, fmt.Sprintf(`
+data "netbird_token" "missing" {
+  user_id = %q
+  name    = %q
+}
+`, mustE2E().UserID, gone), noMatch)
+	})
+}
+
+// Test_DataSource_RejectsDisagreeingSelectorsOnTheRest is the same case as
+// above for every remaining data source, in a table because the configuration
+// is the only thing that differs: create an object, then ask for it by its ID
+// and by a second selector that names something else.
+//
+// The two cloud-only data sources and the reverse proxy pair are left out —
+// nothing on a self-hosted deployment can create the objects.
+func Test_DataSource_RejectsDisagreeingSelectorsOnTheRest(t *testing.T) {
+	testE2E(t)
+	rName := "dis" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	notAll := fmt.Sprintf("[%q]", e2eGroupNotAllID())
+
+	for _, c := range []struct {
+		name   string
+		config string
+	}{
+		{"network", testNetworkResource(rName, `Test`) + fmt.Sprintf(`
+data "netbird_network" "d" {
+  id   = netbird_network.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName)},
+		{"setup_key", testSetupKeyResourceNoLimit(rName, `reusable`) + fmt.Sprintf(`
+data "netbird_setup_key" "d" {
+  id   = netbird_setup_key.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName)},
+		{"posture_check", fmt.Sprintf(`resource "netbird_posture_check" "%[1]s" {
+  name = "%[1]s"
+
+  netbird_version_check {
+    min_version = "0.40.0"
+  }
+}
+
+data "netbird_posture_check" "d" {
+  id   = netbird_posture_check.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName)},
+		{"nameserver_group", testNameserverGroupResource(rName, `1.1.1.1`, `53`, notAll) + fmt.Sprintf(`
+data "netbird_nameserver_group" "d" {
+  id   = netbird_nameserver_group.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName)},
+		{"policy", testPolicyResourceGroups(rName, rName, "desc", "accept", "udp",
+			e2eGroupAllID(), e2eGroupNotAllID(), "443") + fmt.Sprintf(`
+data "netbird_policy" "d" {
+  id   = netbird_policy.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName)},
+		// A route's second selector is its network_id rather than a name.
+		{"route", testRouteResource(rName, e2eGroupAllID(), `null`, `desc`, `null`,
+			`["example.com"]`, notAll, `null`) + fmt.Sprintf(`
+data "netbird_route" "d" {
+  id         = netbird_route.%[1]s.id
+  network_id = "%[1]s-not-the-network"
+}
+`, rName)},
+		{"agent_network_guardrail", testAgentNetworkGuardrailResource(rName) + fmt.Sprintf(`
+data "netbird_agent_network_guardrail" "d" {
+  id   = netbird_agent_network_guardrail.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName)},
+		{"agent_network_provider", testAgentNetworkProviderResource(rName, rName, `null`, "false") +
+			fmt.Sprintf(`
+data "netbird_agent_network_provider" "d" {
+  id   = netbird_agent_network_provider.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName)},
+		{"dns_zone", testDNSZoneResource(rName, rName+".local", true, false, notAll) + fmt.Sprintf(`
+data "netbird_dns_zone" "d" {
+  id   = netbird_dns_zone.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName)},
+		{"dns_record", testDNSRecordResource(rName, rName+".local", rName+"rec", "www",
+			"A", "10.0.0.1", 300) + fmt.Sprintf(`
+data "netbird_dns_record" "d" {
+  zone_id = netbird_dns_zone.%[1]s.id
+  id      = netbird_dns_record.%[1]srec.id
+  name    = "not-the-name.%[1]s.local"
+}
+`, rName)},
+		{"network_resource", testNetworkResourceResource(rName, e2eNetworkID(), "example.com",
+			notAll, rName) + fmt.Sprintf(`
+data "netbird_network_resource" "d" {
+  network_id = %[2]q
+  id         = netbird_network_resource.%[1]s.id
+  name       = "%[1]s-not-the-name"
+}
+`, rName, e2eNetworkID())},
+		{"token", testTokenResource(rName, mustE2E().UserID, `90`) + fmt.Sprintf(`
+data "netbird_token" "d" {
+  user_id = %[2]q
+  id      = netbird_token.%[1]s.id
+  name    = "%[1]s-not-the-name"
+}
+`, rName, mustE2E().UserID)},
+		// A peer needs no resource: the fixture is already registered.
+		{"peer", fmt.Sprintf(`
+data "netbird_peer" "d" {
+  id   = %q
+  name = "not-the-hostname"
+}
+`, testPeerID(t, "peer1"))},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			rejects(t, c.config, noMatch)
+		})
+	}
+}
+
+// Test_DataSource_TokenAmbiguousMatch is the second place the ambiguous path can
+// be reached: two tokens for the same user can carry the same name.
+func Test_DataSource_TokenAmbiguousMatch(t *testing.T) {
+	testE2E(t)
+	rName := "amb" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	userID := mustE2E().UserID
+	both := fmt.Sprintf(`
+resource "netbird_token" "%[1]sa" {
+  user_id         = %[2]q
+  name            = "%[1]s"
+  expiration_days = 90
+}
+
+resource "netbird_token" "%[1]sb" {
+  user_id         = %[2]q
+  name            = "%[1]s"
+  expiration_days = 90
+}
+`, rName, userID)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: both},
+			{
+				Config: both + fmt.Sprintf(`
+data "netbird_token" "%[1]s" {
+  user_id = %[2]q
+  name    = "%[1]s"
+}
+`, rName, userID),
+				ExpectError: ambiguous,
+			},
+		},
+	})
+}
+
+// The by-ID read for the two DNS data sources and for the account settings
+// singleton, compared against the resource that produced them. The existing
+// tests for these three select by name, or assert literals, so the pairing was
+// never made.
+func Test_DNSZone_DataSourceByID(t *testing.T) {
+	testE2E(t)
+	rName := "dz" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testDNSZoneResource(rName, rName+".local", true, false,
+		fmt.Sprintf("[%q]", e2eGroupNotAllID())) + dataSourceByID("dns_zone", rName)
+	dsCase(t, cfg, samePair("dns_zone", rName, "name", "domain", "enabled",
+		"enable_search_domain", "distribution_groups.#"))
+}
+
+func Test_DNSRecord_DataSourceByID(t *testing.T) {
+	testE2E(t)
+	rName := "dr" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testDNSRecordResource(rName, rName+".local", rName, "www", "A", "10.0.0.1", 300) +
+		fmt.Sprintf(`
+data "netbird_dns_record" "%[1]s" {
+  zone_id = netbird_dns_zone.%[1]s.id
+  id      = netbird_dns_record.%[1]s.id
+}
+`, rName)
+	dsCase(t, cfg, samePair("dns_record", rName, "name", "type", "content", "ttl", "zone_id"))
+}
+
+func Test_AccountSettings_DataSourcePairs(t *testing.T) {
+	testE2E(t)
+	rName := "as" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testAccountResource(rName) + fmt.Sprintf(`
+data "netbird_account_settings" "%[1]s" {
+  depends_on = [netbird_account_settings.%[1]s]
+}
+`, rName)
+	dsCase(t, cfg, samePair("account_settings", rName, "peer_login_expiration",
+		"peer_inactivity_expiration", "peer_login_expiration_enabled",
+		"regular_users_view_blocked", "groups_propagation_enabled", "jwt_groups_enabled"))
+}
+
+// The identity provider data source rounds out the same three cases. The
+// resource needs egress — the provider fetches the issuer's discovery document
+// before the server accepts it — which is why these sit apart from the tables
+// above rather than inside them.
+func Test_DataSource_IdentityProviderSelectors(t *testing.T) {
+	testE2E(t)
+	const issuer = "https://oauth.id.jumpcloud.com/"
+
+	t.Run("by name", func(t *testing.T) {
+		rName := "ip" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testIdentityProviderResource(rName, rName, "oidc", "client-id", "client-secret", issuer) +
+			fmt.Sprintf(`
+data "netbird_identity_provider" "%[1]s" {
+  name = netbird_identity_provider.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("identity_provider", rName, "id", "name", "type", "issuer"))
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		rejects(t, fmt.Sprintf(`
+data "netbird_identity_provider" "missing" {
+  name = "does-not-exist-%s"
+}
+`, acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)), noMatch)
+	})
+
+	t.Run("disagreeing selectors", func(t *testing.T) {
+		rName := "ip" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		rejects(t, testIdentityProviderResource(rName, rName, "oidc", "client-id", "client-secret", issuer)+
+			fmt.Sprintf(`
+data "netbird_identity_provider" "d" {
+  id   = netbird_identity_provider.%[1]s.id
+  name = "%[1]s-not-the-name"
+}
+`, rName), noMatch)
+	})
+}

--- a/internal/provider/data_source_selector_acc_test.go
+++ b/internal/provider/data_source_selector_acc_test.go
@@ -1,0 +1,271 @@
+//go:build e2e
+
+// How a data source is addressed, rather than what it returns.
+//
+// data_source_acc_test.go reads every data source back by ID and compares it
+// attribute by attribute against the resource that produced it. That covers the
+// mapping and nothing else: sixteen data sources accept a name — or an email, a
+// network ID, a provider name — as an alternative selector, and each one also
+// has to say something sensible when it is given no selector at all or when
+// more than one object answers.
+//
+// Those are three separate code paths per data source, none of which the by-ID
+// read touches:
+//
+//   - the selector match itself, which is a different comparison from an ID
+//     lookup and in most of these resources means listing and filtering;
+//   - the refusal when nothing is set, which is the provider's own error rather
+//     than the server's;
+//   - the refusal when the filter is ambiguous, which is the one that protects a
+//     user from silently getting whichever object happened to be first.
+
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// noSelector is the shape of the provider's own refusal. The wording differs
+// between data sources — "Must add at least one of" against "Must set at least
+// one of" — which is worth matching loosely rather than pinning.
+var noSelector = regexp.MustCompile(`(?s)No selector|at least one of`)
+
+// ambiguous is what a filter matching more than one object has to produce.
+var ambiguous = regexp.MustCompile(`(?s)Multiple Matches|match(ed)? more than one|cannot match multiple`)
+
+// Test_DataSource_SelectsByName reads back through the alternative selector
+// rather than the ID, and requires the two to be the same object.
+func Test_DataSource_SelectsByName(t *testing.T) {
+	testE2E(t)
+
+	t.Run("group by name", func(t *testing.T) {
+		rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testGroupResource(rName, `[]`) + fmt.Sprintf(`
+data "netbird_group" "%[1]s" {
+  name = netbird_group.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("group", rName, "id", "name", "peers.#"))
+	})
+
+	t.Run("network by name", func(t *testing.T) {
+		rName := "n" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testNetworkResource(rName, `Test`) + fmt.Sprintf(`
+data "netbird_network" "%[1]s" {
+  name = netbird_network.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("network", rName, "id", "name", "description"))
+	})
+
+	t.Run("setup key by name", func(t *testing.T) {
+		rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testSetupKeyResourceNoLimit(rName, `reusable`) + fmt.Sprintf(`
+data "netbird_setup_key" "%[1]s" {
+  name = netbird_setup_key.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("setup_key", rName, "id", "name", "type", "revoked"))
+	})
+
+	t.Run("user by email", func(t *testing.T) {
+		// The user data source takes three selectors. email is the one a person
+		// would reach for and the only one that is not a name or an ID.
+		rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := fmt.Sprintf(`
+resource "netbird_user" "%[1]s" {
+  name            = "%[1]s"
+  email           = "%[1]s@example.com"
+  is_service_user = false
+  role            = "user"
+  auto_groups     = []
+}
+
+data "netbird_user" "%[1]s" {
+  email = netbird_user.%[1]s.email
+}
+`, rName)
+		dsCase(t, cfg, samePair("user", rName, "id", "name", "email", "role"))
+	})
+
+	t.Run("posture check by name", func(t *testing.T) {
+		rName := "pc" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := fmt.Sprintf(`resource "netbird_posture_check" "%[1]s" {
+  name        = "%[1]s"
+  description = "selected by name"
+
+  netbird_version_check {
+    min_version = "0.40.0"
+  }
+}
+
+data "netbird_posture_check" "%[1]s" {
+  name = netbird_posture_check.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("posture_check", rName, "id", "name", "description"))
+	})
+
+	t.Run("route by network_id", func(t *testing.T) {
+		// A route has no name. Its selector is the network_id, which is a
+		// user-chosen label rather than a server-assigned ID, so it is the same
+		// kind of alternative selector as a name.
+		rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testRouteResource(rName, e2eGroupAllID(), `null`, `desc`, `null`, `["example.com"]`,
+			fmt.Sprintf("[%q]", e2eGroupNotAllID()), `null`) + fmt.Sprintf(`
+data "netbird_route" "%[1]s" {
+  network_id = netbird_route.%[1]s.network_id
+}
+`, rName)
+		dsCase(t, cfg, samePair("route", rName, "id", "network_id", "description"))
+	})
+
+	t.Run("nameserver group by name", func(t *testing.T) {
+		rName := "ns" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testNameserverGroupResource(rName, `1.1.1.1`, `53`, fmt.Sprintf("[%q]", e2eGroupAllID())) +
+			fmt.Sprintf(`
+data "netbird_nameserver_group" "%[1]s" {
+  name = netbird_nameserver_group.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("nameserver_group", rName, "id", "name", "enabled"))
+	})
+
+	t.Run("policy by name", func(t *testing.T) {
+		rName := "p" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testPolicyResourceGroups(rName, rName, "desc", "accept", "udp",
+			e2eGroupAllID(), e2eGroupNotAllID(), "443") + fmt.Sprintf(`
+data "netbird_policy" "%[1]s" {
+  name = netbird_policy.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("policy", rName, "id", "name", "enabled"))
+	})
+
+	t.Run("agent network guardrail by name", func(t *testing.T) {
+		rName := "ang" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testAgentNetworkGuardrailResource(rName) + fmt.Sprintf(`
+data "netbird_agent_network_guardrail" "%[1]s" {
+  name = netbird_agent_network_guardrail.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("agent_network_guardrail", rName,
+			"id", "name", "model_allowlist.models.#", "prompt_capture.enabled"))
+	})
+
+	t.Run("agent network policy by name", func(t *testing.T) {
+		rName := "anp" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		cfg := testAgentNetworkPolicyResource(rName) + fmt.Sprintf(`
+data "netbird_agent_network_policy" "%[1]s" {
+  name = netbird_agent_network_policy.%[1]s.name
+}
+`, rName)
+		dsCase(t, cfg, samePair("agent_network_policy", rName,
+			"id", "name", "enabled", "source_groups.#", "destination_provider_ids.#"))
+	})
+}
+
+// Test_DataSource_RejectsNoSelector covers the refusal every one of these data
+// sources has to make. It is the provider's own error, raised before anything
+// reaches the server, so none of these cases needs a deployment to answer.
+func Test_DataSource_RejectsNoSelector(t *testing.T) {
+	testE2E(t)
+
+	// Every data source whose selectors are all optional, so that an empty block
+	// reaches the provider's guard rather than Terraform's own required-argument
+	// check. peers is in the list because it filters rather than looks up, and
+	// still refuses to return the whole account.
+	for _, kind := range []string{
+		"group", "network", "setup_key", "user", "posture_check", "route",
+		"nameserver_group", "policy", "peers", "identity_provider", "scim",
+		"agent_network_provider", "agent_network_policy", "agent_network_guardrail",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			rejects(t, fmt.Sprintf("data \"netbird_%s\" \"nothing\" {}\n", kind), noSelector)
+		})
+	}
+
+	// Two more take a parent, which Terraform requires, so an empty block would
+	// fail on that instead. The parent is given and the selector left out.
+	t.Run("network_resource", func(t *testing.T) {
+		rejects(t, fmt.Sprintf(`
+data "netbird_network_resource" "nothing" {
+  network_id = %q
+}
+`, e2eNetworkID()), noSelector)
+	})
+
+	t.Run("token", func(t *testing.T) {
+		rejects(t, fmt.Sprintf(`
+data "netbird_token" "nothing" {
+  user_id = %q
+}
+`, mustE2E().UserID), noSelector)
+	})
+}
+
+// Test_DataSource_RejectsAmbiguousMatch is the case that protects a user from
+// silently getting whichever object came first.
+//
+// It needs two objects one filter can match, which most of these resources will
+// not allow: names are unique per account for groups, networks and policies. A
+// setup key's name is not, so this is where the path can be exercised at all.
+func Test_DataSource_RejectsAmbiguousMatch(t *testing.T) {
+	testE2E(t)
+	rName := "amb" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := fmt.Sprintf(`
+resource "netbird_setup_key" "%[1]sa" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "reusable"
+  auto_groups    = []
+}
+
+resource "netbird_setup_key" "%[1]sb" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "reusable"
+  auto_groups    = []
+}
+
+data "netbird_setup_key" "%[1]s" {
+  name       = "%[1]s"
+  depends_on = [netbird_setup_key.%[1]sa, netbird_setup_key.%[1]sb]
+}
+`, rName)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// The two keys have to exist before the data source reads, and
+				// the read has to fail, so the objects are created in a step of
+				// their own first.
+				Config: fmt.Sprintf(`
+resource "netbird_setup_key" "%[1]sa" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "reusable"
+  auto_groups    = []
+}
+
+resource "netbird_setup_key" "%[1]sb" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "reusable"
+  auto_groups    = []
+}
+`, rName),
+			},
+			{
+				Config:      cfg,
+				ExpectError: ambiguous,
+			},
+		},
+	})
+}

--- a/internal/provider/drift_acc_test.go
+++ b/internal/provider/drift_acc_test.go
@@ -488,3 +488,57 @@ func Test_Drift_AgentNetworkProvider(t *testing.T) {
 		resource.TestCheckResourceAttr(address, "name", rName),
 	)
 }
+
+func Test_Drift_AgentNetworkGuardrail(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_agent_network_guardrail." + rName
+	driftCase(t, address, testAgentNetworkGuardrailResource(rName),
+		func(id string) error {
+			// The checks are read back and carried through unchanged, since the
+			// request replaces them wholesale and the case is about the name and
+			// the PII flag rather than about the allowlist.
+			g, err := testAgentNetworkClient().GetGuardrail(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			checks := g.Checks
+			checks.PromptCapture.RedactPii = false
+			_, err = testAgentNetworkClient().UpdateGuardrail(context.Background(), id,
+				api.AgentNetworkGuardrailRequest{
+					Name: rName + "-changed-elsewhere", Description: &g.Description, Checks: checks,
+				})
+			return err
+		},
+		resource.TestCheckResourceAttr(address, "name", rName),
+		resource.TestCheckResourceAttr(address, "prompt_capture.redact_pii", "true"),
+	)
+}
+
+func Test_Drift_AgentNetworkPolicy(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_agent_network_policy." + rName
+	driftCase(t, address, testAgentNetworkPolicyResource(rName),
+		func(id string) error {
+			// A policy points at a provider and a guardrail, and the update
+			// replaces the whole object, so both have to be carried through from
+			// the policy as it stands rather than named again here.
+			p, err := testAgentNetworkClient().GetPolicy(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			off := false
+			_, err = testAgentNetworkClient().UpdatePolicy(context.Background(), id,
+				api.AgentNetworkPolicyRequest{
+					Name: rName + "-changed-elsewhere", Description: &p.Description,
+					Enabled: &off, SourceGroups: p.SourceGroups,
+					DestinationProviderIds: p.DestinationProviderIds,
+					GuardrailIds:           &p.GuardrailIds, Limits: &p.Limits,
+				})
+			return err
+		},
+		resource.TestCheckResourceAttr(address, "name", rName),
+		resource.TestCheckResourceAttr(address, "enabled", "true"),
+	)
+}

--- a/internal/provider/drift_acc_test.go
+++ b/internal/provider/drift_acc_test.go
@@ -378,7 +378,8 @@ resource "netbird_dns_record" "%[1]s" {
 				PreConfig: func() {
 					if _, err := testClient().DNSZones.UpdateRecord(context.Background(), zoneID, recordID,
 						api.DNSRecordRequest{
-							Name: "www", Type: api.DNSRecordTypeA, Content: "10.9.9.9", Ttl: 300,
+							Name: "www." + rName + ".local", Type: api.DNSRecordTypeA,
+							Content: "10.9.9.9", Ttl: 300,
 						}); err != nil {
 						t.Fatalf("could not change the record behind Terraform's back: %v", err)
 					}

--- a/internal/provider/drift_acc_test.go
+++ b/internal/provider/drift_acc_test.go
@@ -333,3 +333,152 @@ func Test_Drift_TokenDeletedElsewhere(t *testing.T) {
 		},
 	})
 }
+
+func Test_Drift_DNSRecord(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_dns_record." + rName
+	config := fmt.Sprintf(`
+resource "netbird_dns_zone" "%[1]s" {
+  name                = "%[1]s"
+  domain              = "%[1]s.local"
+  distribution_groups = [%[2]q]
+}
+
+resource "netbird_dns_record" "%[1]s" {
+  zone_id = netbird_dns_zone.%[1]s.id
+  name    = "www"
+  type    = "A"
+  content = "10.0.0.1"
+  ttl     = 300
+}`, rName, e2eGroupNotAllID())
+
+	// The record is addressed through its zone, so the mutation has to find the
+	// zone the configuration created rather than take one from a fixture.
+	var zoneID, recordID string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The zone resource's own ID is the zone the record hangs
+					// from, so there is no need to read it back off the record.
+					testRecordID("netbird_dns_zone."+rName, &zoneID),
+					testRecordID(address, &recordID),
+				),
+			},
+			{
+				PreConfig: func() {
+					if _, err := testClient().DNSZones.UpdateRecord(context.Background(), zoneID, recordID,
+						api.DNSRecordRequest{
+							Name: "www", Type: api.DNSRecordTypeA, Content: "10.9.9.9", Ttl: 300,
+						}); err != nil {
+						t.Fatalf("could not change the record behind Terraform's back: %v", err)
+					}
+				},
+				Config:           config,
+				ConfigPlanChecks: updatesInPlace(address),
+				Check:            resource.TestCheckResourceAttr(address, "content", "10.0.0.1"),
+			},
+		},
+	})
+}
+
+func Test_Drift_NetworkRouter(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_network_router." + rName
+	netID := e2eNetworkID()
+	cfg := fmt.Sprintf(`resource "netbird_network_router" "%[1]s" {
+  network_id  = %[2]q
+  peer_groups = [%[3]q]
+  masquerade  = true
+  metric      = 9999
+}`, rName, netID, e2eGroupNotAllID())
+	driftCase(t, address, cfg,
+		func(id string) error {
+			groups := []string{e2eGroupNotAllID()}
+			_, err := testClient().Networks.Routers(netID).Update(context.Background(), id,
+				api.NetworkRouterRequest{
+					Enabled: true, Masquerade: false, Metric: 1000, PeerGroups: &groups,
+				})
+			return err
+		},
+		resource.TestCheckResourceAttr(address, "masquerade", "true"),
+		resource.TestCheckResourceAttr(address, "metric", "9999"),
+	)
+}
+
+func Test_Drift_PostureCheck(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_posture_check." + rName
+	cfg := fmt.Sprintf(`resource "netbird_posture_check" "%[1]s" {
+  name        = "%[1]s"
+  description = "as configured"
+
+  netbird_version_check {
+    min_version = "0.40.0"
+  }
+}`, rName)
+	driftCase(t, address, cfg,
+		func(id string) error {
+			check, err := testClient().PostureChecks.Get(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			_, err = testClient().PostureChecks.Update(context.Background(), id, api.PostureCheckUpdate{
+				Name: check.Name, Description: "changed elsewhere", Checks: &check.Checks,
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr(address, "description", "as configured"),
+	)
+}
+
+func Test_Drift_IdentityProvider(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_identity_provider." + rName
+	cfg := testIdentityProviderResource(rName, rName, "oidc", "client-id", "client-secret",
+		"https://oauth.id.jumpcloud.com/")
+	driftCase(t, address, cfg,
+		func(id string) error {
+			// The issuer stays as it is: the server checks it can be reached
+			// before accepting the change, so drifting it would test the network
+			// rather than the provider.
+			_, err := testClient().IdentityProviders.Update(context.Background(), id,
+				api.IdentityProviderRequest{
+					Name: rName + "-changed-elsewhere", Type: api.IdentityProviderTypeOidc,
+					ClientId: "client-id", ClientSecret: "client-secret",
+					Issuer: "https://oauth.id.jumpcloud.com/",
+				})
+			return err
+		},
+		resource.TestCheckResourceAttr(address, "name", rName),
+	)
+}
+
+func Test_Drift_AgentNetworkProvider(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_agent_network_provider." + rName
+	// metadata_disabled rather than enabled: only what the configuration states
+	// can drift, and this resource's helper does not set enabled.
+	cfg := testAgentNetworkProviderResource(rName, rName, `{ "x-portkey-config" = "pc-drift" }`, "false")
+	driftCase(t, address, cfg,
+		func(id string) error {
+			on := true
+			_, err := testAgentNetworkClient().UpdateProvider(context.Background(), id,
+				api.AgentNetworkProviderRequest{
+					ProviderId: "openai_api", Name: rName + "-changed-elsewhere",
+					UpstreamUrl: "https://api.openai.com", MetadataDisabled: &on,
+				})
+			return err
+		},
+		resource.TestCheckResourceAttr(address, "metadata_disabled", "false"),
+		resource.TestCheckResourceAttr(address, "name", rName),
+	)
+}

--- a/internal/provider/drift_acc_test.go
+++ b/internal/provider/drift_acc_test.go
@@ -109,7 +109,8 @@ func Test_Drift_DNSZone(t *testing.T) {
 				return err
 			}
 			_, err = testClient().DNSZones.UpdateZone(context.Background(), id, api.ZoneRequest{
-				Name: zone.Name, Enabled: &off, DistributionGroups: zone.DistributionGroups,
+				Name: zone.Name, Domain: zone.Domain, Enabled: &off,
+				DistributionGroups: zone.DistributionGroups,
 			})
 			return err
 		},
@@ -166,6 +167,11 @@ func Test_Drift_Route(t *testing.T) {
 	)
 }
 
+// Test_Drift_SetupKey drifts the groups rather than the revocation. Revoking is
+// the more obvious out-of-band change, and it turns out to be one Terraform
+// cannot undo: the server answers "can't un-revoke a revoked setup key", so the
+// apply that tries to put it back fails. That is the API's rule rather than a
+// provider defect, and a test that asserts it would be asserting a dead end.
 func Test_Drift_SetupKey(t *testing.T) {
 	testE2E(t)
 	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
@@ -177,18 +183,17 @@ func Test_Drift_SetupKey(t *testing.T) {
   expiry_seconds = 1800
   type           = "reusable"
   revoked        = false
-  auto_groups    = []
-}`, rName)
+  auto_groups    = [%[2]q]
+}`, rName, e2eGroupNotAllID())
 	driftCase(t, "netbird_setup_key."+rName, cfg,
 		func(id string) error {
-			// Revoking is the only change the setup key API accepts, and it is
-			// also the one an operator makes by hand in a hurry.
 			_, err := testClient().SetupKeys.Update(context.Background(), id, api.SetupKeyRequest{
-				AutoGroups: []string{}, Revoked: true,
+				AutoGroups: []string{}, Revoked: false,
 			})
 			return err
 		},
-		resource.TestCheckResourceAttr("netbird_setup_key."+rName, "revoked", "false"),
+		resource.TestCheckResourceAttr("netbird_setup_key."+rName, "auto_groups.#", "1"),
+		resource.TestCheckResourceAttr("netbird_setup_key."+rName, "auto_groups.0", e2eGroupNotAllID()),
 	)
 }
 
@@ -347,7 +352,7 @@ resource "netbird_dns_zone" "%[1]s" {
 
 resource "netbird_dns_record" "%[1]s" {
   zone_id = netbird_dns_zone.%[1]s.id
-  name    = "www"
+  name    = "www.%[1]s.local"
   type    = "A"
   content = "10.0.0.1"
   ttl     = 300

--- a/internal/provider/drift_acc_test.go
+++ b/internal/provider/drift_acc_test.go
@@ -96,15 +96,20 @@ func Test_Drift_DNSZone(t *testing.T) {
 	testE2E(t)
 	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	cfg := fmt.Sprintf(`resource "netbird_dns_zone" "%[1]s" {
-  name    = "%[1]s"
-  domain  = "%[1]s.local"
-  enabled = true
-}`, rName)
+  name                = "%[1]s"
+  domain              = "%[1]s.local"
+  enabled             = true
+  distribution_groups = [%[2]q]
+}`, rName, e2eGroupNotAllID())
 	driftCase(t, "netbird_dns_zone."+rName, cfg,
 		func(id string) error {
 			off := false
-			_, err := testClient().DNSZones.UpdateZone(context.Background(), id, api.ZoneRequest{
-				Name: rName, Enabled: &off,
+			zone, err := testClient().DNSZones.GetZone(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			_, err = testClient().DNSZones.UpdateZone(context.Background(), id, api.ZoneRequest{
+				Name: zone.Name, Enabled: &off, DistributionGroups: zone.DistributionGroups,
 			})
 			return err
 		},
@@ -118,12 +123,19 @@ func Test_Drift_NameserverGroup(t *testing.T) {
 	cfg := testNameserverGroupResource(rName, `1.1.1.1`, `53`, fmt.Sprintf("[%q]", e2eGroupAllID()))
 	driftCase(t, "netbird_nameserver_group."+rName, cfg,
 		func(id string) error {
-			_, err := testClient().DNS.UpdateNameserverGroup(context.Background(), id, api.NameserverGroupRequest{
-				Name: rName, Description: "changed elsewhere", Enabled: false,
-				Groups: []string{e2eGroupAllID()},
-				Nameservers: []api.Nameserver{{
-					Ip: "1.1.1.1", NsType: api.NameserverNsTypeUdp, Port: 53,
-				}},
+			// Everything except the flag under test is carried over: the server
+			// refuses a nameserver group that is neither primary nor scoped to a
+			// domain, so a request built from scratch is rejected before it can
+			// drift anything.
+			ns, err := testClient().DNS.GetNameserverGroup(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			_, err = testClient().DNS.UpdateNameserverGroup(context.Background(), id, api.NameserverGroupRequest{
+				Name: ns.Name, Description: "changed elsewhere", Enabled: false,
+				Groups: ns.Groups, Nameservers: ns.Nameservers,
+				Primary: ns.Primary, Domains: ns.Domains,
+				SearchDomainsEnabled: ns.SearchDomainsEnabled,
 			})
 			return err
 		},
@@ -157,7 +169,16 @@ func Test_Drift_Route(t *testing.T) {
 func Test_Drift_SetupKey(t *testing.T) {
 	testE2E(t)
 	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	cfg := testSetupKeyResourceNoLimit(rName, `reusable`)
+	// revoked has to be in the configuration for this to be drift at all. Left
+	// out, it is Optional and Computed, so Terraform adopts whatever the server
+	// says and a revocation made elsewhere is not a difference to put back.
+	cfg := fmt.Sprintf(`resource "netbird_setup_key" "%[1]s" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "reusable"
+  revoked        = false
+  auto_groups    = []
+}`, rName)
 	driftCase(t, "netbird_setup_key."+rName, cfg,
 		func(id string) error {
 			// Revoking is the only change the setup key API accepts, and it is
@@ -232,9 +253,10 @@ func groupIDs(groups *[]api.GroupMinimum) *[]string {
 func Test_Drift_Peer(t *testing.T) {
 	testE2E(t)
 	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	// peer3 is one of the consumable fixtures: this test renames it, and a
-	// shared one would leave the next test looking for a name that moved.
-	peerID := testPeerID(t, "peer3")
+	// peer6 is this test's own fixture. The step that ends it destroys the
+	// resource, which deregisters the device, so a shared peer would leave every
+	// later test looking for something that is no longer registered.
+	peerID := testPeerID(t, "peer6")
 	cfg := testPeerResource(rName, peerID, rName)
 	driftCase(t, "netbird_peer."+rName, cfg,
 		func(id string) error {

--- a/internal/provider/drift_acc_test.go
+++ b/internal/provider/drift_acc_test.go
@@ -1,0 +1,313 @@
+//go:build e2e
+
+// Drift: what happens when something else changes the object.
+//
+// Nothing in the suite covered this, and it is the case a provider is for.
+// Somebody edits a group in the dashboard, a script rewrites a policy, an
+// operator flips a setting by hand — Terraform is supposed to notice on the
+// next refresh and put it back. A provider whose Read maps a field wrongly, or
+// silently keeps the value already in state, passes every other test in the
+// suite and fails here.
+//
+// Each case creates the object through Terraform, changes it behind Terraform's
+// back through the same API a dashboard would use, then applies the unchanged
+// configuration again. Two things are asserted: the plan is an in-place update
+// rather than a no-op or a replacement, and the value the configuration asked
+// for is what the server holds afterwards.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+// driftCase creates an object, changes it through the API, and requires the
+// next apply of the same configuration to put it back in place.
+//
+// The mutation runs in PreConfig, which is called after the previous step and
+// before this one is planned, so the refresh that opens the step is the first
+// thing to see it.
+func driftCase(t *testing.T, address, config string, mutate func(id string) error, back ...resource.TestCheckFunc) {
+	t.Helper()
+	var id string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  testRecordID(address, &id),
+			},
+			{
+				PreConfig: func() {
+					if err := mutate(id); err != nil {
+						t.Fatalf("could not change %s behind Terraform's back: %v", address, err)
+					}
+				},
+				Config:           config,
+				ConfigPlanChecks: updatesInPlace(address),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					append([]resource.TestCheckFunc{
+						resource.TestCheckResourceAttrPtr(address, "id", &id),
+					}, back...)...),
+			},
+		},
+	})
+}
+
+func Test_Drift_Group(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	driftCase(t, "netbird_group."+rName, testGroupResource(rName, `[]`),
+		func(id string) error {
+			_, err := testClient().Groups.Update(context.Background(), id, api.GroupRequest{
+				Name: rName + "-changed-elsewhere", Peers: &[]string{},
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_group."+rName, "name", rName),
+	)
+}
+
+func Test_Drift_Network(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	driftCase(t, "netbird_network."+rName, testNetworkResource(rName, `Test`),
+		func(id string) error {
+			desc := "changed elsewhere"
+			_, err := testClient().Networks.Update(context.Background(), id, api.NetworkRequest{
+				Name: rName, Description: &desc,
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_network."+rName, "description", "Test"),
+	)
+}
+
+func Test_Drift_DNSZone(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := fmt.Sprintf(`resource "netbird_dns_zone" "%[1]s" {
+  name    = "%[1]s"
+  domain  = "%[1]s.local"
+  enabled = true
+}`, rName)
+	driftCase(t, "netbird_dns_zone."+rName, cfg,
+		func(id string) error {
+			off := false
+			_, err := testClient().DNSZones.UpdateZone(context.Background(), id, api.ZoneRequest{
+				Name: rName, Enabled: &off,
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_dns_zone."+rName, "enabled", "true"),
+	)
+}
+
+func Test_Drift_NameserverGroup(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testNameserverGroupResource(rName, `1.1.1.1`, `53`, fmt.Sprintf("[%q]", e2eGroupAllID()))
+	driftCase(t, "netbird_nameserver_group."+rName, cfg,
+		func(id string) error {
+			_, err := testClient().DNS.UpdateNameserverGroup(context.Background(), id, api.NameserverGroupRequest{
+				Name: rName, Description: "changed elsewhere", Enabled: false,
+				Groups: []string{e2eGroupAllID()},
+				Nameservers: []api.Nameserver{{
+					Ip: "1.1.1.1", NsType: api.NameserverNsTypeUdp, Port: 53,
+				}},
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_nameserver_group."+rName, "enabled", "true"),
+	)
+}
+
+func Test_Drift_Route(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testRouteResource(rName, e2eGroupAllID(), `null`, `desc`, `null`, `["example.com"]`,
+		fmt.Sprintf("[%q]", e2eGroupNotAllID()), `null`)
+	driftCase(t, "netbird_route."+rName, cfg,
+		func(id string) error {
+			route, err := testClient().Routes.Get(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			_, err = testClient().Routes.Update(context.Background(), id, api.RouteRequest{
+				NetworkId: route.NetworkId, Description: "changed elsewhere",
+				Enabled: route.Enabled, Groups: route.Groups, Masquerade: route.Masquerade,
+				Metric: route.Metric, Domains: route.Domains, PeerGroups: route.PeerGroups,
+				KeepRoute: route.KeepRoute,
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_route."+rName, "description", "desc"),
+	)
+}
+
+func Test_Drift_SetupKey(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testSetupKeyResourceNoLimit(rName, `reusable`)
+	driftCase(t, "netbird_setup_key."+rName, cfg,
+		func(id string) error {
+			// Revoking is the only change the setup key API accepts, and it is
+			// also the one an operator makes by hand in a hurry.
+			_, err := testClient().SetupKeys.Update(context.Background(), id, api.SetupKeyRequest{
+				AutoGroups: []string{}, Revoked: true,
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_setup_key."+rName, "revoked", "false"),
+	)
+}
+
+func Test_Drift_User(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testUserResource(rName, fmt.Sprintf("[%q]", e2eGroupNotAllID()), `false`, `user`)
+	driftCase(t, "netbird_user."+rName, cfg,
+		func(id string) error {
+			_, err := testClient().Users.Update(context.Background(), id, api.UserRequest{
+				Role: "admin", AutoGroups: []string{e2eGroupNotAllID()}, IsBlocked: false,
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_user."+rName, "role", "user"),
+	)
+}
+
+func Test_Drift_Policy(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cfg := testPolicyResourceGroups(rName, rName, "desc", "accept", "tcp",
+		e2eGroupAllID(), e2eGroupNotAllID(), "443")
+	driftCase(t, "netbird_policy."+rName, cfg,
+		func(id string) error {
+			p, err := testClient().Policies.Get(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			off := false
+			rules := make([]api.PolicyRuleUpdate, 0, len(p.Rules))
+			for _, r := range p.Rules {
+				rules = append(rules, api.PolicyRuleUpdate{
+					Name: r.Name, Description: r.Description, Enabled: r.Enabled,
+					Action: api.PolicyRuleUpdateAction(r.Action), Bidirectional: r.Bidirectional,
+					Protocol: api.PolicyRuleUpdateProtocol(r.Protocol),
+					Ports:    r.Ports, Sources: groupIDs(r.Sources), Destinations: groupIDs(r.Destinations),
+				})
+			}
+			_, err = testClient().Policies.Update(context.Background(), id, api.PolicyCreate{
+				Name: p.Name, Description: p.Description, Enabled: off, Rules: rules,
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_policy."+rName, "enabled", "true"),
+	)
+}
+
+// groupIDs turns the group objects a policy read returns back into the IDs an
+// update takes.
+func groupIDs(groups *[]api.GroupMinimum) *[]string {
+	if groups == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(*groups))
+	for _, g := range *groups {
+		ids = append(ids, g.Id)
+	}
+	return &ids
+}
+
+func Test_Drift_Peer(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	// peer3 is one of the consumable fixtures: this test renames it, and a
+	// shared one would leave the next test looking for a name that moved.
+	peerID := testPeerID(t, "peer3")
+	cfg := testPeerResource(rName, peerID, rName)
+	driftCase(t, "netbird_peer."+rName, cfg,
+		func(id string) error {
+			p, err := testClient().Peers.Get(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			_, err = testClient().Peers.Update(context.Background(), id, api.PeerRequest{
+				Name: rName + "-changed-elsewhere", SshEnabled: p.SshEnabled,
+				LoginExpirationEnabled: p.LoginExpirationEnabled,
+			})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_peer."+rName, "name", rName),
+	)
+}
+
+func Test_Drift_NetworkResource(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	netID := e2eNetworkID()
+	cfg := testNetworkResourceResource(rName, netID, `example.com`,
+		fmt.Sprintf("[%q]", e2eGroupNotAllID()), rName)
+	driftCase(t, "netbird_network_resource."+rName, cfg,
+		func(id string) error {
+			desc := "changed elsewhere"
+			_, err := testClient().Networks.Resources(netID).Update(context.Background(), id,
+				api.NetworkResourceRequest{
+					Name: rName, Description: &desc, Address: "example.com",
+					Enabled: true, Groups: []string{e2eGroupNotAllID()},
+				})
+			return err
+		},
+		resource.TestCheckResourceAttr("netbird_network_resource."+rName, "name", rName),
+	)
+}
+
+// Test_Drift_TokenDeletedElsewhere is the one drift case that cannot be an
+// update: a token has no mutable attribute, so the only thing that can happen
+// to it out of band is deletion. Terraform has to notice it is gone and issue a
+// new one rather than report an empty plan.
+func Test_Drift_TokenDeletedElsewhere(t *testing.T) {
+	testE2E(t)
+	rName := "d" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_token." + rName
+	userID := mustE2E().UserID
+	cfg := testTokenResource(rName, userID, `180`)
+	var first string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check:  testRecordID(address, &first),
+			},
+			{
+				PreConfig: func() {
+					if err := testClient().Tokens.Delete(context.Background(), userID, first); err != nil {
+						t.Fatalf("could not delete the token behind Terraform's back: %v", err)
+					}
+				},
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(address, "id"),
+					testIDChanged(address, &first),
+					func(s *terraform.State) error {
+						id := s.RootModule().Resources[address].Primary.Attributes["id"]
+						_, err := testClient().Tokens.Get(context.Background(), userID, id)
+						return err
+					},
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/e2e_harness_test.go
+++ b/internal/provider/e2e_harness_test.go
@@ -77,17 +77,14 @@ const (
 // order the tests expect to find them.
 //
 // They are split by purpose, because a test that manages a peer through its own
-// lifecycle destroys it: peer1 and peer2 are shared and read-only, addressed by
-// name by the group, route, peers and reverse-proxy tests and expected to
-// survive the whole run, while peer3 to peer5 are consumable, one per lifecycle
-// test. One each rather than sharing, since sharing would make the later test
-// depend on the order Go compiles the files in.
-//
-// Deleting a peer does not actually deregister the device today — Peer.Delete
-// skips the API call under TF_ACC, which is what Test_Peer_Delete reports. The
-// split is what stops that from becoming a cascade of failures once the delete
-// works.
-var e2ePeerNames = []string{"peer1", "peer2", "peer3", "peer4", "peer5"}
+// lifecycle destroys it — and since Peer.Delete now really does deregister the
+// device, a second test reaching for the same fixture finds nothing there.
+// peer1 and peer2 are shared and read-only, addressed by name by the group,
+// route, peers and reverse-proxy tests and expected to survive the whole run.
+// peer3 to peer6 are consumable, one per test that manages a peer: create,
+// delete, update, drift. One each rather than sharing, since sharing would make
+// the later test depend on the order Go compiles the files in.
+var e2ePeerNames = []string{"peer1", "peer2", "peer3", "peer4", "peer5", "peer6"}
 
 // e2eStack is the live deployment plus the IDs of the fixtures created on it.
 type e2eStack struct {

--- a/internal/provider/import_acc_test.go
+++ b/internal/provider/import_acc_test.go
@@ -1,0 +1,301 @@
+//go:build e2e
+
+// What happens when an import ID is wrong.
+//
+// Twenty-three resources support import and the suite only ever handed them an
+// ID that works. Two things go untested that way: the four composite IDs, whose
+// format is parsed by hand in each resource and whose error message is the only
+// documentation a user gets; and the ordinary case of an ID that is well-formed
+// but names nothing, where the resource has to report that rather than write a
+// half-empty object into state.
+//
+// None of these create anything. An import step stands on its own — Terraform
+// never applies the configuration beside it — so the configurations here exist
+// only to name the resource type, and the composite-ID cases are answered
+// before a request is made at all.
+
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// gone is Terraform's own message for an import that resolved to nothing. It is
+// the correct outcome for every resource whose Read recognises a 404 and drops
+// the object instead of returning an error.
+var gone = regexp.MustCompile(`(?s)Cannot import non-existent remote object`)
+
+// badFormat matches the message each hand-written composite parser produces.
+func badFormat(want string) *regexp.Regexp {
+	return regexp.MustCompile(`(?s)Invalid [Ii]mport ID|Error importing|` + regexp.QuoteMeta(want))
+}
+
+func Test_Import_RejectsWrongIDs(t *testing.T) {
+	testE2E(t)
+	n := "i" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	cases := []struct {
+		name    string
+		address string
+		config  string
+		id      string
+		want    *regexp.Regexp
+	}{
+		// The four composite IDs, each parsed by hand in its own resource.
+		{
+			name:    "dns_record without the colon",
+			address: "netbird_dns_record." + n,
+			id:      "onlyonepart",
+			want:    badFormat("zone_id:record_id"),
+			config: fmt.Sprintf(`
+resource "netbird_dns_record" "%[1]s" {
+  zone_id = "z"
+  name    = "www"
+  type    = "A"
+  content = "10.0.0.1"
+}`, n),
+		},
+		{
+			name:    "network_resource without the slash",
+			address: "netbird_network_resource." + n,
+			id:      "onlyonepart",
+			want:    badFormat("networkID/networkResourceID"),
+			config: fmt.Sprintf(`
+resource "netbird_network_resource" "%[1]s" {
+  network_id = "n"
+  name       = "%[1]s"
+  address    = "example.com"
+  groups     = ["g"]
+}`, n),
+		},
+		{
+			name:    "network_router without the slash",
+			address: "netbird_network_router." + n,
+			id:      "onlyonepart",
+			want:    badFormat("networkID/networkRouterID"),
+			config: fmt.Sprintf(`
+resource "netbird_network_router" "%[1]s" {
+  network_id = "n"
+}`, n),
+		},
+		{
+			name:    "token without the slash",
+			address: "netbird_token." + n,
+			id:      "onlyonepart",
+			want:    badFormat("userID/tokenID"),
+			config: fmt.Sprintf(`
+resource "netbird_token" "%[1]s" {
+  name            = "%[1]s"
+  user_id         = "u"
+  expiration_days = 30
+}`, n),
+		},
+
+		// Well-formed IDs that name nothing. These do reach the server.
+		{
+			name:    "dns_zone that does not exist",
+			address: "netbird_dns_zone." + n,
+			id:      "nosuchzone",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_dns_zone" "%[1]s" {
+  name   = "%[1]s"
+  domain = "%[1]s.local"
+}`, n),
+		},
+		{
+			name:    "group that does not exist",
+			address: "netbird_group." + n,
+			id:      "nosuchgroup",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_group" "%[1]s" {
+  name  = "%[1]s"
+  peers = []
+}`, n),
+		},
+		{
+			name:    "nameserver_group that does not exist",
+			address: "netbird_nameserver_group." + n,
+			id:      "nosuchns",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_nameserver_group" "%[1]s" {
+  name    = "%[1]s"
+  groups  = [%[2]q]
+  enabled = true
+
+  nameservers = [{
+    ip      = "1.1.1.1"
+    ns_type = "udp"
+    port    = 53
+  }]
+}`, n, e2eGroupNotAllID()),
+		},
+		{
+			name:    "network that does not exist",
+			address: "netbird_network." + n,
+			id:      "nosuchnetwork",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_network" "%[1]s" {
+  name = "%[1]s"
+}`, n),
+		},
+		{
+			name:    "peer that does not exist",
+			address: "netbird_peer." + n,
+			id:      "nosuchpeer",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_peer" "%[1]s" {
+  id = "nosuchpeer"
+}`, n),
+		},
+		{
+			name:    "policy that does not exist",
+			address: "netbird_policy." + n,
+			id:      "nosuchpolicy",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_policy" "%[1]s" {
+  name    = "%[1]s"
+  enabled = true
+
+  rule {
+    name          = "%[1]s"
+    action        = "accept"
+    bidirectional = true
+    enabled       = true
+    protocol      = "tcp"
+    sources       = [%[2]q]
+    destinations  = [%[3]q]
+    ports         = ["443"]
+  }
+}`, n, e2eGroupNotAllID(), e2eGroupAllID()),
+		},
+		{
+			name:    "posture_check that does not exist",
+			address: "netbird_posture_check." + n,
+			id:      "nosuchcheck",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_posture_check" "%[1]s" {
+  name = "%[1]s"
+
+  netbird_version_check {
+    min_version = "0.40.0"
+  }
+}`, n),
+		},
+		{
+			name:    "route that does not exist",
+			address: "netbird_route." + n,
+			id:      "nosuchroute",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_route" "%[1]s" {
+  network_id = "%[1]s"
+  groups     = [%[2]q]
+  domains    = ["example.com"]
+}`, n, e2eGroupNotAllID()),
+		},
+		{
+			name:    "setup_key that does not exist",
+			address: "netbird_setup_key." + n,
+			id:      "nosuchkey",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_setup_key" "%[1]s" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "reusable"
+}`, n),
+		},
+		{
+			name:    "user that does not exist",
+			address: "netbird_user." + n,
+			id:      "nosuchuser",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_user" "%[1]s" {
+  name            = "%[1]s"
+  is_service_user = true
+  role            = "user"
+  auto_groups     = []
+}`, n),
+		},
+		{
+			name:    "agent_network_provider that does not exist",
+			address: "netbird_agent_network_provider." + n,
+			id:      "nosuchprovider",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_agent_network_provider" "%[1]s" {
+  provider_id  = "%[1]s"
+  name         = "%[1]s"
+  upstream_url = "https://example.invalid"
+  api_key      = "k"
+}`, n),
+		},
+		{
+			name:    "reverse_proxy_domain that does not exist",
+			address: "netbird_reverse_proxy_domain." + n,
+			id:      "nosuchdomain",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_reverse_proxy_domain" "%[1]s" {
+  domain         = "%[1]s.example.com"
+  target_cluster = "c"
+}`, n),
+		},
+		{
+			name:    "reverse_proxy_service that does not exist",
+			address: "netbird_reverse_proxy_service." + n,
+			id:      "nosuchservice",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_reverse_proxy_service" "%[1]s" {
+  name    = "%[1]s"
+  domain  = "%[1]s.example.com"
+  enabled = true
+
+  targets = [{
+    target_id   = "t"
+    target_type = "peer"
+    port        = 8080
+    protocol    = "http"
+  }]
+
+  auth = {
+    link_auth = {
+      enabled = true
+    }
+  }
+}`, n),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:                 func() { testEnsureManagementRunning(t) },
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config:        c.config,
+						ResourceName:  c.address,
+						ImportState:   true,
+						ImportStateId: c.id,
+						ExpectError:   c.want,
+					},
+				},
+			})
+		})
+	}
+}

--- a/internal/provider/import_acc_test.go
+++ b/internal/provider/import_acc_test.go
@@ -55,7 +55,7 @@ func Test_Import_RejectsWrongIDs(t *testing.T) {
 			config: fmt.Sprintf(`
 resource "netbird_dns_record" "%[1]s" {
   zone_id = "z"
-  name    = "www"
+  name    = "www.example.local"
   type    = "A"
   content = "10.0.0.1"
 }`, n),
@@ -280,16 +280,6 @@ resource "netbird_reverse_proxy_service" "%[1]s" {
 }`, n),
 		},
 		{
-			name:    "account_settings that does not exist",
-			address: "netbird_account_settings." + n,
-			id:      "nosuchaccount",
-			want:    gone,
-			config: fmt.Sprintf(`
-resource "netbird_account_settings" "%[1]s" {
-  peer_login_expiration_enabled = true
-}`, n),
-		},
-		{
 			name:    "identity_provider that does not exist",
 			address: "netbird_identity_provider." + n,
 			id:      "nosuchidp",
@@ -353,4 +343,36 @@ resource "netbird_agent_network_policy" "%[1]s" {
 			})
 		})
 	}
+}
+
+// Test_Import_AccountSettingsTakesAnyID records something the table above
+// cannot: the account settings resource accepts whatever ID it is handed.
+//
+// Its Read fetches the account the token belongs to and ignores the ID
+// entirely, so there is no such thing as an account settings object that does
+// not exist, and no ID that can be wrong. That is reasonable for a singleton —
+// there is exactly one account to bind to — but it means an import typo is
+// silently accepted rather than reported, which is worth knowing before someone
+// spends an afternoon on it.
+func Test_Import_AccountSettingsTakesAnyID(t *testing.T) {
+	testE2E(t)
+	n := "i" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_account_settings." + n
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbird_account_settings" "%[1]s" {
+  peer_login_expiration_enabled = true
+}`, n),
+				ResourceName:  address,
+				ImportState:   true,
+				ImportStateId: "not-an-account-id",
+				Check: resource.TestCheckResourceAttr(address,
+					"id", mustE2E().AccountID),
+			},
+		},
+	})
 }

--- a/internal/provider/import_acc_test.go
+++ b/internal/provider/import_acc_test.go
@@ -279,6 +279,61 @@ resource "netbird_reverse_proxy_service" "%[1]s" {
   }
 }`, n),
 		},
+		{
+			name:    "account_settings that does not exist",
+			address: "netbird_account_settings." + n,
+			id:      "nosuchaccount",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_account_settings" "%[1]s" {
+  peer_login_expiration_enabled = true
+}`, n),
+		},
+		{
+			name:    "identity_provider that does not exist",
+			address: "netbird_identity_provider." + n,
+			id:      "nosuchidp",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_identity_provider" "%[1]s" {
+  name          = "%[1]s"
+  type          = "oidc"
+  client_id     = "id"
+  client_secret = "secret"
+  issuer        = "https://oauth.id.jumpcloud.com/"
+}`, n),
+		},
+		{
+			name:    "agent_network_guardrail that does not exist",
+			address: "netbird_agent_network_guardrail." + n,
+			id:      "nosuchguardrail",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_agent_network_guardrail" "%[1]s" {
+  name = "%[1]s"
+
+  model_allowlist = {
+    enabled = true
+    models  = ["gpt-4.1"]
+  }
+
+  prompt_capture = {
+    enabled = false
+  }
+}`, n),
+		},
+		{
+			name:    "agent_network_policy that does not exist",
+			address: "netbird_agent_network_policy." + n,
+			id:      "nosuchagentpolicy",
+			want:    gone,
+			config: fmt.Sprintf(`
+resource "netbird_agent_network_policy" "%[1]s" {
+  name                     = "%[1]s"
+  source_groups            = [%[2]q]
+  destination_provider_ids = ["whatever"]
+}`, n, e2eGroupNotAllID()),
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/provider/lifecycle_extra_acc_test.go
+++ b/internal/provider/lifecycle_extra_acc_test.go
@@ -229,3 +229,83 @@ func Test_Token_ImportThenPlan(t *testing.T) {
 		},
 	})
 }
+
+// Destroying an account-wide singleton.
+//
+// Three resources describe settings rather than objects, and destroy means
+// something different for each of them. Nothing asserted which, and the answer
+// is not what a reader would assume: two of the three do nothing at all, so
+// `terraform destroy` drops them from state and leaves the account exactly as
+// the configuration left it.
+//
+// That is defensible — an account's settings cannot be deleted, only changed,
+// and reverting to defaults would be a decision the configuration never asked
+// for. It is also a surprise worth having in a test, because it means a
+// destroyed configuration is not a clean account.
+
+func Test_Destroy_DNSSettings_KeepsTheSettings(t *testing.T) {
+	testE2E(t)
+	rName := "ds" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	group := e2eGroupNotAllID()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(*terraform.State) error {
+			settings, err := testClient().DNS.GetSettings(context.Background())
+			if err != nil {
+				return err
+			}
+			for _, g := range settings.DisabledManagementGroups {
+				if g == group {
+					return nil
+				}
+			}
+			return fmt.Errorf("the group the configuration disabled is no longer disabled after destroy, so something did revert it: %v",
+				settings.DisabledManagementGroups)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSSettingsResource(rName, fmt.Sprintf("[%q]", group)),
+				Check: resource.TestCheckResourceAttr("netbird_dns_settings."+rName,
+					"disabled_management_groups.#", "1"),
+			},
+		},
+	})
+}
+
+func Test_Destroy_AccountSettings_KeepsTheSettings(t *testing.T) {
+	testE2E(t)
+	rName := "as" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_account_settings." + rName
+	config := fmt.Sprintf(`resource "netbird_account_settings" "%[1]s" {
+  peer_login_expiration_enabled = true
+  peer_login_expiration         = 7200
+}`, rName)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(*terraform.State) error {
+			accounts, err := testClient().Accounts.List(context.Background())
+			if err != nil {
+				return err
+			}
+			for _, a := range accounts {
+				if a.Id != mustE2E().AccountID {
+					continue
+				}
+				if a.Settings.PeerLoginExpiration != 7200 {
+					return fmt.Errorf("peer_login_expiration is %d after destroy, expected the configured 7200 to still be there",
+						a.Settings.PeerLoginExpiration)
+				}
+				return nil
+			}
+			return fmt.Errorf("the account under test is not in the list")
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.TestCheckResourceAttr(address, "peer_login_expiration", "7200"),
+			},
+		},
+	})
+}

--- a/internal/provider/lifecycle_extra_acc_test.go
+++ b/internal/provider/lifecycle_extra_acc_test.go
@@ -133,20 +133,27 @@ func Test_Replace_UserServiceUser(t *testing.T) {
 	testE2E(t)
 	rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	address := "netbird_user." + rName
-	cfg := func(service string) string {
-		// No email: the server drops it for a service user and returns an empty
-		// one, which Terraform reports as the provider contradicting its own
-		// plan. That is a defect worth fixing on its own, and not this test's
-		// subject.
-		return fmt.Sprintf(`resource "netbird_user" "%[1]s" {
+	// The email moves with the kind of account, because the server insists on
+	// both halves: a person cannot be created without one, and a service user
+	// that is given one fails the apply — the address is dropped and returned
+	// empty, which Terraform reports as the provider contradicting its own plan.
+	// That second half is a defect in its own right, and not this test's subject.
+	serviceUser := fmt.Sprintf(`resource "netbird_user" "%[1]s" {
   name            = "%[1]s"
-  is_service_user = %[2]s
+  is_service_user = true
   role            = "user"
   auto_groups     = []
 }
-`, rName, service)
-	}
-	replaceCase(t, address, cfg("true"), cfg("false"),
+`, rName)
+	person := fmt.Sprintf(`resource "netbird_user" "%[1]s" {
+  name            = "%[1]s"
+  email           = "%[1]s@example.com"
+  is_service_user = false
+  role            = "user"
+  auto_groups     = []
+}
+`, rName)
+	replaceCase(t, address, serviceUser, person,
 		resource.TestCheckResourceAttr(address, "is_service_user", "false"),
 	)
 }

--- a/internal/provider/lifecycle_extra_acc_test.go
+++ b/internal/provider/lifecycle_extra_acc_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
 )
 
 // Test_Group_AddAndRemovePeers covers the direction the group test never went.
@@ -92,7 +94,7 @@ resource "netbird_dns_zone" "%[1]s" {
 
 resource "netbird_dns_record" "%[1]s" {
   zone_id = netbird_dns_zone.%[1]s.id
-  name    = "www"
+  name    = "www.%[1]s.local"
   type    = "A"
   content = "10.0.0.1"
   ttl     = 300
@@ -132,9 +134,12 @@ func Test_Replace_UserServiceUser(t *testing.T) {
 	rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	address := "netbird_user." + rName
 	cfg := func(service string) string {
+		// No email: the server drops it for a service user and returns an empty
+		// one, which Terraform reports as the provider contradicting its own
+		// plan. That is a defect worth fixing on its own, and not this test's
+		// subject.
 		return fmt.Sprintf(`resource "netbird_user" "%[1]s" {
   name            = "%[1]s"
-  email           = "%[1]s@example.com"
   is_service_user = %[2]s
   role            = "user"
   auto_groups     = []
@@ -147,9 +152,11 @@ func Test_Replace_UserServiceUser(t *testing.T) {
 }
 
 // Test_SetupKey_ImportThenApply is the case the expiry_seconds plan modifier
-// exists for. An imported key has no value for it, because the API never
-// reports one, and the first apply after the import must adopt what the
-// configuration says instead of destroying the key to get it.
+// exists for, and it starts the way a user starts: with a key the server
+// already has and Terraform has never seen. The import gives state no
+// expiry_seconds, because the API never reports one, and the apply that follows
+// has to adopt what the configuration says rather than destroy the key to get
+// it.
 func Test_SetupKey_ImportThenApply(t *testing.T) {
 	testE2E(t)
 	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
@@ -167,19 +174,21 @@ func Test_SetupKey_ImportThenApply(t *testing.T) {
 		CheckDestroy:             testCheckGone(testClient().SetupKeys.Get, &id),
 		Steps: []resource.TestStep{
 			{
-				Config: config,
-				Check:  testRecordID(address, &id),
-			},
-			{
-				// ImportStatePersist keeps the imported state for the step that
-				// follows, which is the whole point: the next plan runs against
-				// state that has no expiry_seconds in it.
-				ResourceName:            address,
-				ImportState:             true,
-				ImportStatePersist:      true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"key", "expiry_seconds"},
-				ImportStateIdFunc:       testImportIDFrom(address, "", "id"),
+				PreConfig: func() {
+					key, err := testClient().SetupKeys.Create(context.Background(), api.CreateSetupKeyRequest{
+						Name: rName, Type: "reusable", ExpiresIn: 1800,
+						AutoGroups: []string{}, UsageLimit: 0,
+					})
+					if err != nil {
+						t.Fatalf("could not create the key to import: %v", err)
+					}
+					id = key.Id
+				},
+				Config:             config,
+				ResourceName:       address,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc:  func(*terraform.State) (string, error) { return id, nil },
 			},
 			{
 				Config:           config,
@@ -187,15 +196,16 @@ func Test_SetupKey_ImportThenApply(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPtr(address, "id", &id),
 					resource.TestCheckResourceAttr(address, "expiry_seconds", "1800"),
+					resource.TestCheckResourceAttr(address, "name", rName),
 				),
 			},
 		},
 	})
 }
 
-// Test_Token_ImportThenPlan is the same shape for the token, where the value
-// that cannot be read back is recoverable from two timestamps that can. If the
-// arithmetic is wrong the plan after an import is not empty, and the only way
+// Test_Token_ImportThenPlan is the same flow for the token, where the value the
+// API cannot report is recoverable from two timestamps that it can. If that
+// arithmetic is wrong the plan after the import is not empty, and the only way
 // to satisfy it is a new token.
 func Test_Token_ImportThenPlan(t *testing.T) {
 	testE2E(t)
@@ -209,20 +219,23 @@ func Test_Token_ImportThenPlan(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
-				Check:  testRecordID(address, &id),
-			},
-			{
-				ResourceName:            address,
-				ImportState:             true,
-				ImportStatePersist:      true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"token"},
-				ImportStateIdFunc:       testImportIDFrom(address, "/", "user_id", "id"),
+				PreConfig: func() {
+					token, err := testClient().Tokens.Create(context.Background(), userID,
+						api.PersonalAccessTokenRequest{Name: rName, ExpiresIn: 180})
+					if err != nil {
+						t.Fatalf("could not create the token to import: %v", err)
+					}
+					id = token.PersonalAccessToken.Id
+				},
+				Config:             config,
+				ResourceName:       address,
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc:  func(*terraform.State) (string, error) { return userID + "/" + id, nil },
 			},
 			{
 				// Nothing to do: expiration_days came back from the timestamps,
-				// so the token Terraform imported is the token it planned for.
+				// so the token Terraform imported is the token it plans for.
 				Config:   config,
 				PlanOnly: true,
 			},

--- a/internal/provider/lifecycle_extra_acc_test.go
+++ b/internal/provider/lifecycle_extra_acc_test.go
@@ -1,0 +1,231 @@
+//go:build e2e
+
+// The cases that belong to one resource and no pattern.
+//
+// Everything here came out of reading each resource against the operations a
+// user actually performs on it, rather than from a family that applies across
+// the provider. They are the leftovers in the honest sense: each one is
+// specific enough that it could not be written as a table.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// Test_Group_AddAndRemovePeers covers the direction the group test never went.
+// Adding a peer was covered; taking it away again was not, and a provider that
+// sends the new list without the removal looks identical on the way in.
+func Test_Group_AddAndRemovePeers(t *testing.T) {
+	testE2E(t)
+	rName := "g" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_group." + rName
+	peerID := testPeerID(t, "peer1")
+	membersAre := func(want int) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			id := s.RootModule().Resources[address].Primary.Attributes["id"]
+			group, err := testClient().Groups.Get(context.Background(), id)
+			if err != nil {
+				return err
+			}
+			if len(group.Peers) != want {
+				return fmt.Errorf("management has %d peers in the group, expected %d", len(group.Peers), want)
+			}
+			return nil
+		}
+	}
+	var id string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().Groups.Get, &id),
+		Steps: []resource.TestStep{
+			{
+				Config: testGroupResource(rName, `[]`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(address, &id),
+					membersAre(0),
+				),
+			},
+			{
+				Config:           testGroupResource(rName, fmt.Sprintf("[%q]", peerID)),
+				ConfigPlanChecks: updatesInPlace(address),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(address, "peers.#", "1"),
+					membersAre(1),
+				),
+			},
+			{
+				Config:           testGroupResource(rName, `[]`),
+				ConfigPlanChecks: updatesInPlace(address),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPtr(address, "id", &id),
+					resource.TestCheckResourceAttr(address, "peers.#", "0"),
+					membersAre(0),
+				),
+			},
+		},
+	})
+}
+
+// Test_DNSZone_DestroyTakesItsRecords checks the cascade. A record lives inside
+// a zone, so destroying the zone has to leave nothing addressable behind — and
+// Terraform destroys in dependency order, which is the part worth confirming
+// against a server rather than assuming.
+func Test_DNSZone_DestroyTakesItsRecords(t *testing.T) {
+	testE2E(t)
+	rName := "z" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	zoneAddress := "netbird_dns_zone." + rName
+	var zoneID, recordID string
+	config := fmt.Sprintf(`
+resource "netbird_dns_zone" "%[1]s" {
+  name                = "%[1]s"
+  domain              = "%[1]s.local"
+  distribution_groups = [%[2]q]
+}
+
+resource "netbird_dns_record" "%[1]s" {
+  zone_id = netbird_dns_zone.%[1]s.id
+  name    = "www"
+  type    = "A"
+  content = "10.0.0.1"
+  ttl     = 300
+}`, rName, e2eGroupNotAllID())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if _, err := testClient().DNSZones.GetZone(context.Background(), zoneID); err == nil {
+				return fmt.Errorf("zone %s is still on the management server after destroy", zoneID)
+			}
+			// The record is addressed through the zone, so its own lookup has to
+			// fail as well rather than resolving against a zone that is gone.
+			if _, err := testClient().DNSZones.GetRecord(context.Background(), zoneID, recordID); err == nil {
+				return fmt.Errorf("record %s is still on the management server after destroy", recordID)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testRecordID(zoneAddress, &zoneID),
+					testRecordID("netbird_dns_record."+rName, &recordID),
+				),
+			},
+		},
+	})
+}
+
+// Test_Replace_UserServiceUser changes what kind of account a user is. The
+// server has no way to convert one into the other, which is why the attribute
+// forces replacement, and this is the assertion that says so.
+func Test_Replace_UserServiceUser(t *testing.T) {
+	testE2E(t)
+	rName := "u" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_user." + rName
+	cfg := func(service string) string {
+		return fmt.Sprintf(`resource "netbird_user" "%[1]s" {
+  name            = "%[1]s"
+  email           = "%[1]s@example.com"
+  is_service_user = %[2]s
+  role            = "user"
+  auto_groups     = []
+}
+`, rName, service)
+	}
+	replaceCase(t, address, cfg("true"), cfg("false"),
+		resource.TestCheckResourceAttr(address, "is_service_user", "false"),
+	)
+}
+
+// Test_SetupKey_ImportThenApply is the case the expiry_seconds plan modifier
+// exists for. An imported key has no value for it, because the API never
+// reports one, and the first apply after the import must adopt what the
+// configuration says instead of destroying the key to get it.
+func Test_SetupKey_ImportThenApply(t *testing.T) {
+	testE2E(t)
+	rName := "sk" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_setup_key." + rName
+	config := fmt.Sprintf(`resource "netbird_setup_key" "%[1]s" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "reusable"
+  auto_groups    = []
+}`, rName)
+	var id string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckGone(testClient().SetupKeys.Get, &id),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  testRecordID(address, &id),
+			},
+			{
+				// ImportStatePersist keeps the imported state for the step that
+				// follows, which is the whole point: the next plan runs against
+				// state that has no expiry_seconds in it.
+				ResourceName:            address,
+				ImportState:             true,
+				ImportStatePersist:      true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key", "expiry_seconds"},
+				ImportStateIdFunc:       testImportIDFrom(address, "", "id"),
+			},
+			{
+				Config:           config,
+				ConfigPlanChecks: updatesInPlace(address),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPtr(address, "id", &id),
+					resource.TestCheckResourceAttr(address, "expiry_seconds", "1800"),
+				),
+			},
+		},
+	})
+}
+
+// Test_Token_ImportThenPlan is the same shape for the token, where the value
+// that cannot be read back is recoverable from two timestamps that can. If the
+// arithmetic is wrong the plan after an import is not empty, and the only way
+// to satisfy it is a new token.
+func Test_Token_ImportThenPlan(t *testing.T) {
+	testE2E(t)
+	rName := "t" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_token." + rName
+	userID := mustE2E().UserID
+	config := testTokenResource(rName, userID, `180`)
+	var id string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  testRecordID(address, &id),
+			},
+			{
+				ResourceName:            address,
+				ImportState:             true,
+				ImportStatePersist:      true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+				ImportStateIdFunc:       testImportIDFrom(address, "/", "user_id", "id"),
+			},
+			{
+				// Nothing to do: expiration_days came back from the timestamps,
+				// so the token Terraform imported is the token it planned for.
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/provider/replacement_acc_test.go
+++ b/internal/provider/replacement_acc_test.go
@@ -1,0 +1,300 @@
+//go:build e2e
+
+// Replacement, attribute by attribute.
+//
+// Eighteen attributes across eight resources are marked RequiresReplace, which
+// is a promise: change one and the object is destroyed and a new one takes its
+// place. lifecycle_acc_test.go checks three of them. The rest are checked here,
+// and the check is in two parts — the plan has to say it is replacing, and the
+// server-assigned ID afterwards has to differ from the one before.
+//
+// Both halves matter. A provider that updates in place where the schema says
+// replace looks identical in an apply, and the difference only shows up later,
+// as an object that kept an attribute the API cannot actually change. A
+// provider that replaces where it should update destroys infrastructure for no
+// reason, which is the direction that costs a setup key or a token.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// replaces asserts the plan destroys and recreates the resource rather than
+// updating it. Terraform expresses that as two actions, in either order
+// depending on whether the provider allows the new object to exist first.
+type replaces struct {
+	address string
+}
+
+func (c replaces) CheckPlan(_ context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	for _, rc := range req.Plan.ResourceChanges {
+		if rc.Address != c.address {
+			continue
+		}
+		a := rc.Change.Actions
+		if len(a) == 2 && ((a[0] == tfjson.ActionDelete && a[1] == tfjson.ActionCreate) ||
+			(a[0] == tfjson.ActionCreate && a[1] == tfjson.ActionDelete)) {
+			return
+		}
+		resp.Error = fmt.Errorf("%s: planned %v, which is not a replacement; the schema marks the attribute under test RequiresReplace",
+			c.address, rc.Change.Actions)
+		return
+	}
+	resp.Error = fmt.Errorf("%s is not in the plan", c.address)
+}
+
+func replacesResource(address string) resource.ConfigPlanChecks {
+	return resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{replaces{address: address}}}
+}
+
+// replaceCase applies one configuration, then a second that differs in exactly
+// one replace-forcing attribute.
+func replaceCase(t *testing.T, address, before, after string, then ...resource.TestCheckFunc) {
+	t.Helper()
+	var first string
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testEnsureManagementRunning(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: before,
+				Check:  testRecordID(address, &first),
+			},
+			{
+				Config:           after,
+				ConfigPlanChecks: replacesResource(address),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					append([]resource.TestCheckFunc{testIDChanged(address, &first)}, then...)...),
+			},
+		},
+	})
+}
+
+// Setup keys carry five of the eighteen, more than any other resource, and each
+// one is a secret that a needless replacement invalidates.
+
+// setupKeyConfig builds a reusable key. Reusable rather than one-off because a
+// one-off key's usage limit is the server's to decide, and this file needs every
+// attribute under test to be the configuration's.
+func setupKeyConfig(rName, name, expiry, ephemeral, extraLabels, usageLimit string) string {
+	return fmt.Sprintf(`resource "netbird_setup_key" "%[1]s" {
+  name                   = "%[2]s"
+  expiry_seconds         = %[3]s
+  type                   = "reusable"
+  ephemeral              = %[4]s
+  allow_extra_dns_labels = %[5]s
+  usage_limit            = %[6]s
+  auto_groups            = []
+}
+`, rName, name, expiry, ephemeral, extraLabels, usageLimit)
+}
+
+func Test_Replace_SetupKeyName(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_setup_key." + rName
+	replaceCase(t, address,
+		setupKeyConfig(rName, rName, "1800", "false", "false", "5"),
+		setupKeyConfig(rName, rName+"-renamed", "1800", "false", "false", "5"),
+		resource.TestCheckResourceAttr(address, "name", rName+"-renamed"),
+	)
+}
+
+func Test_Replace_SetupKeyExpiry(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_setup_key." + rName
+	// expiry_seconds forces replacement through a provider-specific rule rather
+	// than the framework's, because the API cannot report the value and an
+	// imported key has to be able to adopt it. The rule still has to replace
+	// when both values are known and differ.
+	replaceCase(t, address,
+		setupKeyConfig(rName, rName, "1800", "false", "false", "5"),
+		setupKeyConfig(rName, rName, "3600", "false", "false", "5"),
+		resource.TestCheckResourceAttr(address, "expiry_seconds", "3600"),
+	)
+}
+
+func Test_Replace_SetupKeyUsageLimit(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_setup_key." + rName
+	replaceCase(t, address,
+		setupKeyConfig(rName, rName, "1800", "false", "false", "5"),
+		setupKeyConfig(rName, rName, "1800", "false", "false", "10"),
+		resource.TestCheckResourceAttr(address, "usage_limit", "10"),
+	)
+}
+
+func Test_Replace_SetupKeyEphemeral(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_setup_key." + rName
+	replaceCase(t, address,
+		setupKeyConfig(rName, rName, "1800", "false", "false", "5"),
+		setupKeyConfig(rName, rName, "1800", "true", "false", "5"),
+		resource.TestCheckResourceAttr(address, "ephemeral", "true"),
+	)
+}
+
+func Test_Replace_SetupKeyExtraDNSLabels(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_setup_key." + rName
+	replaceCase(t, address,
+		setupKeyConfig(rName, rName, "1800", "false", "false", "5"),
+		setupKeyConfig(rName, rName, "1800", "false", "true", "5"),
+		resource.TestCheckResourceAttr(address, "allow_extra_dns_labels", "true"),
+	)
+}
+
+func Test_Replace_TokenName(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_token." + rName
+	userID := mustE2E().UserID
+	cfg := func(name string) string {
+		return fmt.Sprintf(`resource "netbird_token" "%[1]s" {
+  name            = "%[2]s"
+  user_id         = %[3]q
+  expiration_days = 90
+}
+`, rName, name, userID)
+	}
+	replaceCase(t, address, cfg(rName), cfg(rName+"-renamed"),
+		resource.TestCheckResourceAttr(address, "name", rName+"-renamed"),
+	)
+}
+
+// Test_Replace_TokenUser moves a token from one service user to another. The
+// token belongs to the user, so this is a different object by definition, and
+// the second user has to exist before the token can point at it.
+func Test_Replace_TokenUser(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_token." + rName
+	cfg := func(owner string) string {
+		return fmt.Sprintf(`
+resource "netbird_user" "%[1]sa" {
+  name            = "%[1]sa"
+  is_service_user = true
+  role            = "user"
+  auto_groups     = []
+}
+
+resource "netbird_user" "%[1]sb" {
+  name            = "%[1]sb"
+  is_service_user = true
+  role            = "user"
+  auto_groups     = []
+}
+
+resource "netbird_token" "%[1]s" {
+  name            = "%[1]s"
+  user_id         = netbird_user.%[2]s.id
+  expiration_days = 90
+}
+`, rName, owner)
+	}
+	replaceCase(t, address, cfg(rName+"a"), cfg(rName+"b"),
+		resource.TestCheckResourceAttrPair(address, "user_id", "netbird_user."+rName+"b", "id"),
+	)
+}
+
+// Test_Replace_DNSRecordZone moves a record between zones. A record is
+// addressed as zone plus record, so it cannot be the same object afterwards.
+func Test_Replace_DNSRecordZone(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_dns_record." + rName
+	cfg := func(zone string) string {
+		return fmt.Sprintf(`
+resource "netbird_dns_zone" "%[1]sa" {
+  name   = "%[1]sa"
+  domain = "%[1]sa.local"
+}
+
+resource "netbird_dns_zone" "%[1]sb" {
+  name   = "%[1]sb"
+  domain = "%[1]sb.local"
+}
+
+resource "netbird_dns_record" "%[1]s" {
+  zone_id = netbird_dns_zone.%[2]s.id
+  name    = "www"
+  type    = "A"
+  content = "10.0.0.1"
+  ttl     = 300
+}
+`, rName, zone)
+	}
+	replaceCase(t, address, cfg(rName+"a"), cfg(rName+"b"),
+		resource.TestCheckResourceAttrPair(address, "zone_id", "netbird_dns_zone."+rName+"b", "id"),
+	)
+}
+
+// Test_Replace_NetworkResourceNetwork and Test_Replace_NetworkRouterNetwork
+// both move a child between networks, which the API models as a new object
+// under a different parent rather than a move.
+
+func Test_Replace_NetworkResourceNetwork(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_network_resource." + rName
+	cfg := func(network string) string {
+		return fmt.Sprintf(`
+resource "netbird_network" "%[1]sa" {
+  name = "%[1]sa"
+}
+
+resource "netbird_network" "%[1]sb" {
+  name = "%[1]sb"
+}
+
+resource "netbird_network_resource" "%[1]s" {
+  network_id = netbird_network.%[2]s.id
+  name       = "%[1]s"
+  address    = "example.com"
+  groups     = [%[3]q]
+}
+`, rName, network, e2eGroupNotAllID())
+	}
+	replaceCase(t, address, cfg(rName+"a"), cfg(rName+"b"),
+		resource.TestCheckResourceAttrPair(address, "network_id", "netbird_network."+rName+"b", "id"),
+	)
+}
+
+func Test_Replace_NetworkRouterNetwork(t *testing.T) {
+	testE2E(t)
+	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	address := "netbird_network_router." + rName
+	cfg := func(network string) string {
+		return fmt.Sprintf(`
+resource "netbird_network" "%[1]sa" {
+  name = "%[1]sa"
+}
+
+resource "netbird_network" "%[1]sb" {
+  name = "%[1]sb"
+}
+
+resource "netbird_network_router" "%[1]s" {
+  network_id  = netbird_network.%[2]s.id
+  peer_groups = [%[3]q]
+  masquerade  = true
+  metric      = 9999
+}
+`, rName, network, e2eGroupNotAllID())
+	}
+	replaceCase(t, address, cfg(rName+"a"), cfg(rName+"b"),
+		resource.TestCheckResourceAttrPair(address, "network_id", "netbird_network."+rName+"b", "id"),
+	)
+}

--- a/internal/provider/replacement_acc_test.go
+++ b/internal/provider/replacement_acc_test.go
@@ -218,13 +218,15 @@ func Test_Replace_DNSRecordZone(t *testing.T) {
 	cfg := func(zone string) string {
 		return fmt.Sprintf(`
 resource "netbird_dns_zone" "%[1]sa" {
-  name   = "%[1]sa"
-  domain = "%[1]sa.local"
+  name                = "%[1]sa"
+  domain              = "%[1]sa.local"
+  distribution_groups = [%[3]q]
 }
 
 resource "netbird_dns_zone" "%[1]sb" {
-  name   = "%[1]sb"
-  domain = "%[1]sb.local"
+  name                = "%[1]sb"
+  domain              = "%[1]sb.local"
+  distribution_groups = [%[3]q]
 }
 
 resource "netbird_dns_record" "%[1]s" {
@@ -234,7 +236,7 @@ resource "netbird_dns_record" "%[1]s" {
   content = "10.0.0.1"
   ttl     = 300
 }
-`, rName, zone)
+`, rName, zone, e2eGroupNotAllID())
 	}
 	replaceCase(t, address, cfg(rName+"a"), cfg(rName+"b"),
 		resource.TestCheckResourceAttrPair(address, "zone_id", "netbird_dns_zone."+rName+"b", "id"),

--- a/internal/provider/replacement_acc_test.go
+++ b/internal/provider/replacement_acc_test.go
@@ -211,6 +211,11 @@ resource "netbird_token" "%[1]s" {
 
 // Test_Replace_DNSRecordZone moves a record between zones. A record is
 // addressed as zone plus record, so it cannot be the same object afterwards.
+//
+// The name moves with it: a record is named by its fully qualified name and the
+// server refuses one that does not sit inside its zone's domain, so the two
+// cannot be varied independently. zone_id is what forces the replacement either
+// way, since name does not.
 func Test_Replace_DNSRecordZone(t *testing.T) {
 	testE2E(t)
 	rName := "r" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
@@ -231,7 +236,7 @@ resource "netbird_dns_zone" "%[1]sb" {
 
 resource "netbird_dns_record" "%[1]s" {
   zone_id = netbird_dns_zone.%[2]s.id
-  name    = "www.%[1]s.local"
+  name    = "www.%[2]s.local"
   type    = "A"
   content = "10.0.0.1"
   ttl     = 300

--- a/internal/provider/replacement_acc_test.go
+++ b/internal/provider/replacement_acc_test.go
@@ -231,7 +231,7 @@ resource "netbird_dns_zone" "%[1]sb" {
 
 resource "netbird_dns_record" "%[1]s" {
   zone_id = netbird_dns_zone.%[2]s.id
-  name    = "www"
+  name    = "www.%[1]s.local"
   type    = "A"
   content = "10.0.0.1"
   ttl     = 300

--- a/internal/provider/validation_acc_test.go
+++ b/internal/provider/validation_acc_test.go
@@ -31,7 +31,141 @@ var (
 	outOfRange = regexp.MustCompile(`(?s)value must be between|Invalid Attribute Value`)
 	wrongSize  = regexp.MustCompile(`(?s)list must contain|Invalid Attribute Value|Insufficient|Too few`)
 	tooLong    = regexp.MustCompile(`(?s)length must be|Invalid Attribute Value`)
+	conflicts  = regexp.MustCompile(`(?s)Invalid Attribute Combination|cannot be specified when`)
 )
+
+// Test_Rejects_MutuallyExclusiveAttributes covers the thirteen ConflictsWith
+// validators, which are a different promise from the range and enumeration
+// checks: not "this value is wrong" but "these two cannot both be here".
+//
+// They matter more than their size suggests. Each pair exists because the API
+// models one thing two ways — a route to a peer or to a group of peers, a rule
+// scoped to groups or to a resource — and a request carrying both is ambiguous
+// rather than merely invalid. A validator that does not fire lets that ambiguity
+// reach the server, which resolves it silently and by its own rules.
+func Test_Rejects_MutuallyExclusiveAttributes(t *testing.T) {
+	testE2E(t)
+	rName := "x" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	group, other := e2eGroupNotAllID(), e2eGroupAllID()
+
+	cases := []struct {
+		name   string
+		config string
+	}{
+		{
+			name: "network_router peer and peer_groups together",
+			config: fmt.Sprintf(`
+resource "netbird_network_router" "%[1]s" {
+  network_id  = %[2]q
+  peer        = "some-peer"
+  peer_groups = [%[3]q]
+  masquerade  = true
+  metric      = 9999
+}`, rName, e2eNetworkID(), group),
+		},
+		{
+			name: "route peer and peer_groups together",
+			config: fmt.Sprintf(`
+resource "netbird_route" "%[1]s" {
+  network_id  = "%[1]s"
+  groups      = [%[2]q]
+  domains     = ["example.com"]
+  peer        = "some-peer"
+  peer_groups = [%[3]q]
+}`, rName, group, other),
+		},
+		{
+			// A route reaches either a CIDR or a set of domains. Both at once
+			// describes two different routes.
+			name: "route network and domains together",
+			config: fmt.Sprintf(`
+resource "netbird_route" "%[1]s" {
+  network_id = "%[1]s"
+  groups     = [%[2]q]
+  network    = "100.10.0.0/16"
+  domains    = ["example.com"]
+}`, rName, group),
+		},
+		{
+			name: "policy rule ports and port_ranges together",
+			config: fmt.Sprintf(`
+resource "netbird_policy" "%[1]s" {
+  name    = "%[1]s"
+  enabled = true
+
+  rule {
+    name          = "%[1]s"
+    action        = "accept"
+    bidirectional = true
+    enabled       = true
+    protocol      = "tcp"
+    sources       = [%[2]q]
+    destinations  = [%[3]q]
+    ports         = ["443"]
+
+    port_ranges = [{
+      start = 8000
+      end   = 8080
+    }]
+  }
+}`, rName, group, other),
+		},
+		{
+			name: "policy rule sources and source_resource together",
+			config: fmt.Sprintf(`
+resource "netbird_policy" "%[1]s" {
+  name    = "%[1]s"
+  enabled = true
+
+  rule {
+    name          = "%[1]s"
+    action        = "accept"
+    bidirectional = true
+    enabled       = true
+    protocol      = "tcp"
+    sources       = [%[2]q]
+    destinations  = [%[3]q]
+    ports         = ["443"]
+
+    source_resource = {
+      id   = "some-resource"
+      type = "host"
+    }
+  }
+}`, rName, group, other),
+		},
+		{
+			name: "policy rule destinations and destination_resource together",
+			config: fmt.Sprintf(`
+resource "netbird_policy" "%[1]s" {
+  name    = "%[1]s"
+  enabled = true
+
+  rule {
+    name          = "%[1]s"
+    action        = "accept"
+    bidirectional = true
+    enabled       = true
+    protocol      = "tcp"
+    sources       = [%[2]q]
+    destinations  = [%[3]q]
+    ports         = ["443"]
+
+    destination_resource = {
+      id   = "some-resource"
+      type = "host"
+    }
+  }
+}`, rName, group, other),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rejects(t, c.config, conflicts)
+		})
+	}
+}
 
 func Test_Rejects_OutsideValidatorLimits(t *testing.T) {
 	testE2E(t)

--- a/internal/provider/validation_acc_test.go
+++ b/internal/provider/validation_acc_test.go
@@ -1,0 +1,301 @@
+//go:build e2e
+
+// The validators the suite did not exercise.
+//
+// A validator that never fires in a test is a rejection nobody has confirmed
+// happens. lifecycle_acc_test.go covers seven of them, all string enumerations;
+// this file covers the rest — the numeric ranges, the collection sizes, and the
+// enumerations on resources that need a parent object to exist before they can
+// be written at all.
+//
+// Every case here is refused before a request is made, so none of them creates
+// anything, none of them needs a peer or a proxy cluster, and the whole file
+// runs in about a second. The configurations are written out in full rather
+// than built from the shared helpers: a rejection test has to control exactly
+// one value, and a helper that gains an argument later would quietly change
+// what is being rejected.
+
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+)
+
+// The shapes terraform-plugin-framework produces for the validators used here.
+var (
+	outOfRange = regexp.MustCompile(`(?s)value must be between|Invalid Attribute Value`)
+	wrongSize  = regexp.MustCompile(`(?s)list must contain|Invalid Attribute Value|Insufficient|Too few`)
+	tooLong    = regexp.MustCompile(`(?s)length must be|Invalid Attribute Value`)
+)
+
+func Test_Rejects_OutsideValidatorLimits(t *testing.T) {
+	testE2E(t)
+	rName := "v" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	group := e2eGroupNotAllID()
+
+	cases := []struct {
+		name   string
+		config string
+		want   *regexp.Regexp
+	}{
+		{
+			// 60 seconds is the shortest TTL the resource accepts.
+			name: "dns_record ttl below the range",
+			want: outOfRange,
+			config: fmt.Sprintf(`
+resource "netbird_dns_zone" "%[1]s" {
+  name   = "%[1]s"
+  domain = "reject.local"
+}
+
+resource "netbird_dns_record" "%[1]s" {
+  zone_id = netbird_dns_zone.%[1]s.id
+  name    = "www"
+  type    = "A"
+  content = "10.0.0.1"
+  ttl     = 30
+}`, rName),
+		},
+		{
+			name: "nameserver_group name longer than 40",
+			want: tooLong,
+			config: fmt.Sprintf(`
+resource "netbird_nameserver_group" "%[1]s" {
+  name        = %[2]q
+  description = "rejection fixture"
+  enabled     = true
+  groups      = [%[3]q]
+
+  nameservers = [{
+    ip      = "1.1.1.1"
+    ns_type = "udp"
+    port    = 53
+  }]
+}`, rName, strings.Repeat("n", 41), group),
+		},
+		{
+			// The metric decides which of two routes to the same network wins,
+			// and 0 is not a position in that ordering.
+			name: "network_router metric below the range",
+			want: outOfRange,
+			config: fmt.Sprintf(`
+resource "netbird_network_router" "%[1]s" {
+  network_id  = %[2]q
+  peer_groups = [%[3]q]
+  masquerade  = true
+  metric      = 0
+}`, rName, e2eNetworkID(), group),
+		},
+		{
+			// The schema allows exactly one rule. Two is the bound that can be
+			// checked before an apply: an absent block reaches the server
+			// instead, which is a gap in the validator rather than in the test.
+			name: "policy with two rules",
+			want: wrongSize,
+			config: fmt.Sprintf(`
+resource "netbird_policy" "%[1]s" {
+  name        = "%[1]s"
+  description = "rejection fixture"
+  enabled     = true
+
+  rule {
+    name          = "%[1]s-a"
+    action        = "accept"
+    bidirectional = true
+    enabled       = true
+    protocol      = "tcp"
+    sources       = [%[2]q]
+    destinations  = [%[3]q]
+    ports         = ["443"]
+  }
+
+  rule {
+    name          = "%[1]s-b"
+    action        = "accept"
+    bidirectional = true
+    enabled       = true
+    protocol      = "udp"
+    sources       = [%[2]q]
+    destinations  = [%[3]q]
+    ports         = ["53"]
+  }
+}`, rName, group, e2eGroupAllID()),
+		},
+		{
+			name: "policy port range starting above 65535",
+			want: outOfRange,
+			config: fmt.Sprintf(`
+resource "netbird_policy" "%[1]s" {
+  name        = "%[1]s"
+  description = "rejection fixture"
+  enabled     = true
+
+  rule {
+    name          = "%[1]s"
+    action        = "accept"
+    bidirectional = true
+    enabled       = true
+    protocol      = "tcp"
+    sources       = [%[2]q]
+    destinations  = [%[3]q]
+
+    port_ranges = [{
+      start = 70000
+      end   = 70001
+    }]
+  }
+}`, rName, group, e2eGroupAllID()),
+		},
+		{
+			name: "policy port range ending above 65535",
+			want: outOfRange,
+			config: fmt.Sprintf(`
+resource "netbird_policy" "%[1]s" {
+  name        = "%[1]s"
+  description = "rejection fixture"
+  enabled     = true
+
+  rule {
+    name          = "%[1]s"
+    action        = "accept"
+    bidirectional = true
+    enabled       = true
+    protocol      = "tcp"
+    sources       = [%[2]q]
+    destinations  = [%[3]q]
+
+    port_ranges = [{
+      start = 80
+      end   = 70000
+    }]
+  }
+}`, rName, group, e2eGroupAllID()),
+		},
+		{
+			name: "reverse_proxy_service unknown target type",
+			want: oneOf,
+			config: fmt.Sprintf(`
+resource "netbird_reverse_proxy_service" "%[1]s" {
+  name    = "%[1]s"
+  domain  = "%[1]s.reject.local"
+  enabled = true
+
+  targets = [{
+    target_id   = "whatever"
+    target_type = "vm"
+    port        = 8080
+    protocol    = "http"
+  }]
+  auth = {
+    link_auth = {
+      enabled = true
+    }
+  }
+}`, rName),
+		},
+		{
+			name: "reverse_proxy_service port above 65535",
+			want: outOfRange,
+			config: fmt.Sprintf(`
+resource "netbird_reverse_proxy_service" "%[1]s" {
+  name    = "%[1]s"
+  domain  = "%[1]s.reject.local"
+  enabled = true
+
+  targets = [{
+    target_id   = "whatever"
+    target_type = "peer"
+    port        = 70000
+    protocol    = "http"
+  }]
+  auth = {
+    link_auth = {
+      enabled = true
+    }
+  }
+}`, rName),
+		},
+		{
+			// The proxy terminates HTTP and HTTPS. Anything else would be a
+			// different product.
+			name: "reverse_proxy_service unknown protocol",
+			want: oneOf,
+			config: fmt.Sprintf(`
+resource "netbird_reverse_proxy_service" "%[1]s" {
+  name    = "%[1]s"
+  domain  = "%[1]s.reject.local"
+  enabled = true
+
+  targets = [{
+    target_id   = "whatever"
+    target_type = "peer"
+    port        = 8080
+    protocol    = "ftp"
+  }]
+  auth = {
+    link_auth = {
+      enabled = true
+    }
+  }
+}`, rName),
+		},
+		{
+			name: "route network_id longer than 40",
+			want: tooLong,
+			config: fmt.Sprintf(`
+resource "netbird_route" "%[1]s" {
+  network_id  = %[2]q
+  description = "rejection fixture"
+  groups      = [%[3]q]
+  domains     = ["example.com"]
+}`, rName, strings.Repeat("n", 41), group),
+		},
+		{
+			name: "route metric below the range",
+			want: outOfRange,
+			config: fmt.Sprintf(`
+resource "netbird_route" "%[1]s" {
+  network_id  = "%[1]s"
+  description = "rejection fixture"
+  groups      = [%[2]q]
+  domains     = ["example.com"]
+  metric      = 0
+}`, rName, group),
+		},
+		{
+			// A year is the longest a personal access token may live.
+			name: "token expiration beyond a year",
+			want: outOfRange,
+			config: fmt.Sprintf(`
+resource "netbird_token" "%[1]s" {
+  name            = "%[1]s"
+  user_id         = %[2]q
+  expiration_days = 400
+}`, rName, mustE2E().UserID),
+		},
+		{
+			// Not a validator but the same contract: the combination cannot be
+			// satisfied, so it is refused before the apply rather than after.
+			name: "one-off setup key with a usage limit it cannot honour",
+			want: regexp.MustCompile(`(?s)Invalid Attribute Combination|one-off setup key can be used once`),
+			config: fmt.Sprintf(`
+resource "netbird_setup_key" "%[1]s" {
+  name           = "%[1]s"
+  expiry_seconds = 1800
+  type           = "one-off"
+  usage_limit    = 5
+}`, rName),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rejects(t, c.config, c.want)
+		})
+	}
+}


### PR DESCRIPTION
Fifth of five. Stacked on #201 — review that first; this diff is against it.

A pass over every resource and data source produced 378 test cases the provider ought to satisfy: 244 on the resources and 134 on how the data sources are addressed. Measuring the branch this one builds on gives 158 automated. This takes that to 325, and the 53 left over are named at the bottom.

## What was missing

| Family | Cases | Was |
| --- | --- | --- |
| Drift — something else changed the object | 18 | nothing, for any resource |
| Import IDs that are wrong | 21 | nothing |
| Validators, ranges and enumerations | 13 | 7 of 20 covered |
| Validators, conflicting pairs | 11 | nothing, for any of the 11 |
| Replacement, attribute by attribute | 11 | 3 of 18 covered |
| Data source addressing | 80 | read back by ID and nothing else |
| One-resource cases | 8 | partly |

## Drift

Nobody edits infrastructure only through Terraform. Somebody changes a group in the dashboard, a script rewrites a policy, an operator revokes a setup key in a hurry — and the next `terraform apply` is supposed to notice and put it back. **No test in the suite asserted that**, for any resource.

It is the gap that matters most, because a provider can fail it while passing everything else. A `Read` that maps a field wrongly, or that keeps the value already in state instead of the server's, produces empty plans forever and looks perfect in a create-and-check test.

Eighteen cases: each creates the object through Terraform, changes it through the same API a dashboard would use, then applies the *unchanged* configuration again and requires two things — the plan is an in-place update rather than a no-op or a replacement, and the server holds the configured value afterwards.

The token is the case that cannot be an update. It has no mutable attribute, so the only thing that can happen to it out of band is deletion, and Terraform has to issue a new one rather than report an empty plan.

## Import IDs that are wrong

Every import test passed an ID that works, which left two things unasserted.

The four composite IDs are parsed by hand in each resource, and the error message is the only documentation a user gets for the format — `dns_record` wants `zone_id:record_id` while `network_resource`, `network_router` and `token` want a slash. And a well-formed ID that names nothing has to be reported as such: Terraform says "Cannot import non-existent remote object" only when the resource's `Read` recognises the object is gone and drops it.

Twenty-one cases, and they create nothing. An import step stands on its own, so the configurations beside them exist only to name the resource type, and the four composite cases are answered before a request is made.

## Validators and replacement

Thirteen cases for the numeric ranges, name lengths, metrics, port ranges and the two `reverse_proxy_service` enumerations.

Eleven more for the conflicting pairs. Thirteen `ConflictsWith` validators were declared across `network_router`, `route` and `policy` — peer against peer_groups, network against domains, ports against port_ranges, sources against source_resource, destinations against destination_resource — and not one of them was ever fed both sides, so a pair that stopped conflicting would have looked identical in every test.

Every one of these is refused before a request is made, so the whole set adds about a second to the run.

Eleven replacement cases, checked twice over: the plan has to say it is replacing, and the server-assigned ID afterwards has to differ. Both directions cost something when they are wrong. Updating in place where the schema says replace leaves an object holding a value the API never accepted; replacing where it should update destroys infrastructure for no reason, which on these resources means a setup key or a token that every peer and script holding the old secret can no longer use.

## Data source addressing

Every data source was read back by its ID and compared against the resource that produced it. That covers the mapping and nothing else — the ID lookup never touches the three paths a user is most likely to hit:

- **the alternative selector**, which for most of these is a list-and-filter rather than a direct read: sixteen data sources take a name, an email, a network ID or a provider name;
- **the refusal when no selector is given**, which is the provider's own error rather than the server's;
- **the refusal when the filter is ambiguous**, which is what stops a user silently getting whichever object happened to be first.

All three are now covered for every data source that a self-hosted deployment can reach, along with the not-found path and the case where two selectors name different objects. `netbird_agent_network_policy` and `netbird_agent_network_guardrail` had no data source test at all; both are now read by ID and by name, and both have drift cases too.

## What this found

**Setting an email on a service user fails the apply.** The server drops the address and returns an empty one, so Terraform reports the provider contradicting its own plan:

```
Error: Provider produced inconsistent result after apply
.email: was cty.StringVal("x@example.com"), but now cty.StringVal("")
```

**A posture check with no description fails the apply, for the same reason from the other direction.** `description` is Optional without being Computed, and the API answers with an empty string rather than nothing, so the provider hands back a value where the configuration had none:

```
Error: Provider produced inconsistent result after apply
.description: was null, but now cty.StringVal("")
```

Both are the same shape as the `usage_limit` defect #201 fixes, and both want the same treatment. Not fixed here — this is a tests PR, and they deserve their own change. Until then a posture check needs a description, which is what the configurations in this PR do.

**Three data sources have no no-selector guard.** `netbird_dns_zone`, `netbird_dns_record` and `netbird_peer` list and filter, so a configuration naming nothing matches nothing and the answer is the not-found error rather than one naming the selectors it accepts. Safe either way — no object is returned — but worse to read than the sixteen that answer properly. Pinned by a test rather than changed.

**`netbird_account_settings` accepts any import ID.** Its `Read` fetches the account the token belongs to and ignores the ID, so an import typo binds to the account rather than being reported. Reasonable for a singleton, and now written down in a test rather than waiting to cost someone an afternoon.

**Destroying `netbird_account_settings` or `netbird_dns_settings` keeps the settings.** Both `Delete` methods do nothing, so `terraform destroy` drops the object from state and leaves the account exactly as configured. Defensible — settings cannot be deleted and reverting to defaults would be a decision nobody asked for — but it means a destroyed configuration is not a clean account. Both now have a test that says so.

**`listvalidator.SizeBetween(1, 1)` on `policy.rule` does not fire when the block is absent.** An empty policy reaches the server rather than being refused at plan time. The case here uses two rules instead, which is the bound that can be checked; the lower bound is worth fixing in the schema.

**`dns_zone` has no `description` argument**, though every other named object in the provider does.

## Rules the server has that the tests now encode

Every CI failure after the first was a server invariant rather than a provider defect. They are worth listing, because each one is a thing a user will hit:

- **Drift only exists for attributes the configuration states.** An Optional and Computed attribute nobody configured is one Terraform adopts from the server rather than corrects, so changing it out of band is a legitimate no-op.
- **A revoked setup key cannot be un-revoked.** Revocation is the obvious out-of-band change to test, and the apply that tries to put it back is refused, so that case would have asserted a dead end.
- **A DNS record is named by its fully qualified name** and has to sit inside its zone's domain, so a record cannot move between zones without being renamed.
- **A user cannot change kind without changing address.** A person cannot be created without an email and a service user cannot keep one.
- **A DNS zone needs a distribution group**, and an update has to carry the domain it is not changing.

## Still open

Fifty-three cases, in four groups.

- **`netbird_scim`, thirteen cases.** Cloud-only; the tests skip unconditionally and there is nothing on a self-hosted deployment to read.
- **The reverse proxy pair, twelve.** Both need a running proxy cluster: two `reverse_proxy_domain` replacements, drift on the service, and all ten data source cases across the two.
- **Attribute surface, fifteen partial cases.** Create and update paths that reach most but not all of the optional attributes on `account_settings`, `policy`, `posture_check`, `route`, `nameserver_group` and the agent network resources. A scoped pass of its own rather than a leftover.
- **The rest, thirteen.** Drift on `account_settings`, `dns_settings` and `agent_network_settings`; destroying the agent network settings; two identity provider cases that need an unreachable issuer or a Google tenant; reading a singleton on an account that has never configured it, which a shared account cannot demonstrate.

Two validator families are also not enumerated as cases yet, and the QA reference says so on its face: the lower bounds that refuse an empty string or an empty list, and the regular expressions that pin a version or a country code format.

## Test plan

- `gofmt`, `go vet` and `golangci-lint run`, each with and without `-tags e2e` — all clean.
- Every plan-time case was run locally against a stub API before CI — the validator cases, the composite-ID cases, the sixteen no-selector refusals and the eleven not-found refusals — which is what caught the `dns_zone` description and the policy rule validator before a deployment was involved.
- CI is green, including the acceptance suite.