### PR TITLE
[provider] Map redacted auth secrets to null, not empty string

### DIFF
--- a/internal/provider/reverse_proxy_service_resource.go
+++ b/internal/provider/reverse_proxy_service_resource.go
@@ -584,6 +584,16 @@ func targetOptionsTerraformToAPI(ctx context.Context, opts types.Object) (*api.S
 	return result, ret
 }
 
+// redactedSecretAPIToTerraform maps the blank the API returns for a secret to null.
+// An empty string never matches a configuration that omits the secret, so it would
+// show a diff on every plan.
+func redactedSecretAPIToTerraform(secret string) types.String {
+	if secret == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(secret)
+}
+
 func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, data *ReverseProxyServiceModel) diag.Diagnostics {
 	var ret diag.Diagnostics
 	var d diag.Diagnostics
@@ -650,7 +660,7 @@ func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, da
 	if svc.Auth.PasswordAuth != nil {
 		authModel.PasswordAuth, d = types.ObjectValueFrom(ctx, ReverseProxyPasswordAuthModel{}.TFType().AttrTypes, ReverseProxyPasswordAuthModel{
 			Enabled:  types.BoolValue(svc.Auth.PasswordAuth.Enabled),
-			Password: types.StringValue(svc.Auth.PasswordAuth.Password),
+			Password: redactedSecretAPIToTerraform(svc.Auth.PasswordAuth.Password),
 		})
 		ret.Append(d...)
 	} else {
@@ -660,7 +670,7 @@ func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, da
 	if svc.Auth.PinAuth != nil {
 		authModel.PinAuth, d = types.ObjectValueFrom(ctx, ReverseProxyPinAuthModel{}.TFType().AttrTypes, ReverseProxyPinAuthModel{
 			Enabled: types.BoolValue(svc.Auth.PinAuth.Enabled),
-			Pin:     types.StringValue(svc.Auth.PinAuth.Pin),
+			Pin:     redactedSecretAPIToTerraform(svc.Auth.PinAuth.Pin),
 		})
 		ret.Append(d...)
 	} else {
@@ -698,7 +708,7 @@ func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, da
 			headerAuthModels = append(headerAuthModels, ReverseProxyHeaderAuthModel{
 				Enabled: types.BoolValue(h.Enabled),
 				Header:  types.StringValue(h.Header),
-				Value:   types.StringValue(h.Value),
+				Value:   redactedSecretAPIToTerraform(h.Value),
 			})
 		}
 		authModel.HeaderAuths, d = types.ListValueFrom(ctx, ReverseProxyHeaderAuthModel{}.TFType(), headerAuthModels)
@@ -745,8 +755,8 @@ func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, da
 	return ret
 }
 
-// preserveAuthSecrets copies sensitive auth fields (password, pin) from prior state/plan
-// into the current model since the API redacts these values on read.
+// preserveAuthSecrets copies sensitive auth fields (password, pin, header auth values)
+// from prior state/plan into the current model, since the API never returns them.
 // It also preserves the structure of optional auth blocks (like link_auth) that the API
 // may not return when disabled, ensuring state matches plan.
 func preserveAuthSecrets(priorAuth, currentAuth types.Object) (types.Object, diag.Diagnostics) {

--- a/internal/provider/reverse_proxy_service_resource.go
+++ b/internal/provider/reverse_proxy_service_resource.go
@@ -594,6 +594,10 @@ func redactedSecretAPIToTerraform(secret string) types.String {
 	return types.StringValue(secret)
 }
 
+// reverseProxyServiceAPIToTerraform fills the Terraform model from a service the API returned,
+// defaulting the fields the API may omit. Auth secrets are mapped through
+// redactedSecretAPIToTerraform, so the blanks the API returns in their place become null;
+// callers that hold a prior state or plan restore the real values with preserveAuthSecrets.
 func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, data *ReverseProxyServiceModel) diag.Diagnostics {
 	var ret diag.Diagnostics
 	var d diag.Diagnostics

--- a/internal/provider/reverse_proxy_service_resource.go
+++ b/internal/provider/reverse_proxy_service_resource.go
@@ -536,6 +536,8 @@ func targetOptionsAPIToTerraform(ctx context.Context, opts *api.ServiceTargetOpt
 	return obj, d
 }
 
+// targetOptionsTerraformToAPI maps the target options block to the API type, skipping unset
+// attributes. Returns nil when none is set, so an empty block keeps the server defaults.
 func targetOptionsTerraformToAPI(ctx context.Context, opts types.Object) (*api.ServiceTargetOptions, diag.Diagnostics) {
 	if opts.IsNull() || opts.IsUnknown() {
 		return nil, nil
@@ -584,9 +586,8 @@ func targetOptionsTerraformToAPI(ctx context.Context, opts types.Object) (*api.S
 	return result, ret
 }
 
-// redactedSecretAPIToTerraform maps the blank the API returns for a secret to null.
-// An empty string never matches a configuration that omits the secret, so it would
-// show a diff on every plan.
+// redactedSecretAPIToTerraform maps the blank the API returns for a secret to null. An empty
+// string never matches a configuration that omits the secret, so it would diff on every plan.
 func redactedSecretAPIToTerraform(secret string) types.String {
 	if secret == "" {
 		return types.StringNull()
@@ -594,10 +595,8 @@ func redactedSecretAPIToTerraform(secret string) types.String {
 	return types.StringValue(secret)
 }
 
-// reverseProxyServiceAPIToTerraform fills the Terraform model from a service the API returned,
-// defaulting the fields the API may omit. Auth secrets are mapped through
-// redactedSecretAPIToTerraform, so the blanks the API returns in their place become null;
-// callers that hold a prior state or plan restore the real values with preserveAuthSecrets.
+// reverseProxyServiceAPIToTerraform fills the model from an API service, defaulting the fields
+// the API may omit. Blanked auth secrets become null; preserveAuthSecrets restores them.
 func reverseProxyServiceAPIToTerraform(ctx context.Context, svc *api.Service, data *ReverseProxyServiceModel) diag.Diagnostics {
 	var ret diag.Diagnostics
 	var d diag.Diagnostics

--- a/internal/provider/reverse_proxy_service_test.go
+++ b/internal/provider/reverse_proxy_service_test.go
@@ -1247,6 +1247,7 @@ func Test_reverseProxyServiceDataSourceSchema(t *testing.T) {
 	var _ datasource.DataSource = &ReverseProxyServiceDataSource{}
 }
 
+// Header auth is a list: a round trip must keep every entry, its value, and the order.
 func Test_reverseProxyServiceRoundtrip_headerAuth(t *testing.T) {
 	ctx := context.Background()
 
@@ -1298,8 +1299,7 @@ func Test_reverseProxyServiceRoundtrip_headerAuth(t *testing.T) {
 	}
 }
 
-// assertMappedSecret checks the mapped value of an auth secret: null when the API
-// blanked it, the value itself otherwise.
+// assertMappedSecret checks a mapped auth secret: null when the API blanked it, the value otherwise.
 func assertMappedSecret(t *testing.T, value attr.Value, apiValue, field string) {
 	t.Helper()
 
@@ -1318,13 +1318,10 @@ func assertMappedSecret(t *testing.T, value attr.Value, apiValue, field string) 
 	}
 }
 
-// The API never returns auth secrets (ToAPIResponse builds the auth config without
-// them), so state must hold null. For password and pin, which are Optional, "" would
-// show a diff against a configuration that omits them; header_auths[].value is
-// Required, so null there is
-// truthfulness rather than convergence. Mapping back, a null must become a blank inside an
-// enabled auth block: dropping the block would disable the auth method. The
-// "value present" case guards the branch that must leave a real value alone.
+// The API never returns auth secrets, so state must hold null: for Optional password and pin an
+// empty string diffs against a configuration that omits them. Mapping back, null must become a
+// blank inside an enabled block, or the auth method would be dropped. The "value present" case
+// covers the branch that leaves a real value alone.
 func Test_reverseProxyServiceRoundtrip_authSecrets(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -1438,6 +1435,7 @@ func Test_reverseProxyServiceRoundtrip_authSecrets(t *testing.T) {
 	}
 }
 
+// Access restrictions are optional on both sides: a round trip must not drop the block or its lists.
 func Test_reverseProxyServiceRoundtrip_accessRestrictions(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/provider/reverse_proxy_service_test.go
+++ b/internal/provider/reverse_proxy_service_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -1294,6 +1295,146 @@ func Test_reverseProxyServiceRoundtrip_headerAuth(t *testing.T) {
 	}
 	if headers[1].Header != "Authorization" || headers[1].Value != "Bearer token123" {
 		t.Errorf("Second header auth mismatch: got %+v", headers[1])
+	}
+}
+
+// assertMappedSecret checks the mapped value of an auth secret: null when the API
+// blanked it, the value itself otherwise.
+func assertMappedSecret(t *testing.T, value attr.Value, apiValue, field string) {
+	t.Helper()
+
+	s, ok := value.(types.String)
+	if !ok {
+		t.Fatalf("%s should be a types.String, got %T", field, value)
+	}
+	if apiValue == "" {
+		if !s.IsNull() {
+			t.Errorf("%s should be null when the API redacts it, got %q", field, s.ValueString())
+		}
+		return
+	}
+	if s.ValueString() != apiValue {
+		t.Errorf("%s mismatch: expected %q, got %q", field, apiValue, s.ValueString())
+	}
+}
+
+// The API never returns auth secrets (ToAPIResponse builds the auth config without
+// them), so state must hold null. For password and pin, which are Optional, "" would
+// show a diff against a configuration that omits them; header_auths[].value is
+// Required, so null there is
+// truthfulness rather than convergence. Mapping back, a null must become a blank inside an
+// enabled auth block: dropping the block would disable the auth method. The
+// "value present" case guards the branch that must leave a real value alone.
+func Test_reverseProxyServiceRoundtrip_authSecrets(t *testing.T) {
+	cases := []struct {
+		name   string
+		secret string
+	}{
+		{name: "blanked by the API", secret: ""},
+		{name: "value present", secret: "s3cret"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			original := &api.Service{
+				Id:      "svc-secrets-rt",
+				Name:    "auth-secrets-roundtrip",
+				Domain:  "secrets-rt.example.com",
+				Enabled: true,
+				Targets: []api.ServiceTarget{
+					{
+						TargetId:   "peer1",
+						TargetType: api.ServiceTargetTargetTypePeer,
+						Port:       80,
+						Protocol:   api.ServiceTargetProtocolHttp,
+						Enabled:    true,
+					},
+				},
+				Auth: api.ServiceAuthConfig{
+					PasswordAuth: &api.PasswordAuthConfig{Enabled: true, Password: c.secret},
+					PinAuth:      &api.PINAuthConfig{Enabled: true, Pin: c.secret},
+					// The second header is never blank, so the redacted case also proves the
+					// loop maps each entry independently.
+					HeaderAuths: &[]api.HeaderAuthConfig{
+						{Enabled: true, Header: "X-API-Key", Value: c.secret},
+						{Enabled: true, Header: "X-Tenant", Value: "always-set"},
+					},
+				},
+			}
+
+			var model ReverseProxyServiceModel
+			if d := reverseProxyServiceAPIToTerraform(ctx, original, &model); d.HasError() {
+				t.Fatalf("APIToTerraform failed with %d errors", d.ErrorsCount())
+			}
+
+			authAttrs := model.Auth.Attributes()
+
+			pwObj, ok := authAttrs["password_auth"].(types.Object)
+			if !ok || pwObj.IsNull() {
+				t.Fatal("password_auth should be set when the API returns it")
+			}
+			assertMappedSecret(t, pwObj.Attributes()["password"], c.secret, "password_auth.password")
+			if enabled, ok := pwObj.Attributes()["enabled"].(types.Bool); !ok || !enabled.ValueBool() {
+				t.Error("password_auth.enabled should survive the mapping")
+			}
+
+			pinObj, ok := authAttrs["pin_auth"].(types.Object)
+			if !ok || pinObj.IsNull() {
+				t.Fatal("pin_auth should be set when the API returns it")
+			}
+			assertMappedSecret(t, pinObj.Attributes()["pin"], c.secret, "pin_auth.pin")
+			if enabled, ok := pinObj.Attributes()["enabled"].(types.Bool); !ok || !enabled.ValueBool() {
+				t.Error("pin_auth.enabled should survive the mapping")
+			}
+
+			headers, ok := authAttrs["header_auths"].(types.List)
+			if !ok || len(headers.Elements()) != 2 {
+				t.Fatalf("header_auths should hold the two entries the API returned, got %v", headers)
+			}
+			for i, want := range []string{c.secret, "always-set"} {
+				headerObj, ok := headers.Elements()[i].(types.Object)
+				if !ok {
+					t.Fatalf("header_auths[%d] should be an object", i)
+				}
+				assertMappedSecret(t, headerObj.Attributes()["value"], want, fmt.Sprintf("header_auths[%d].value", i))
+			}
+
+			req, d := reverseProxyServiceTerraformToAPI(ctx, &model)
+			if d.HasError() {
+				t.Fatalf("TerraformToAPI failed with %d errors", d.ErrorsCount())
+			}
+			if req.Auth == nil {
+				t.Fatal("Auth should be sent")
+			}
+
+			if req.Auth.PasswordAuth == nil {
+				t.Fatal("PasswordAuth should be sent, not dropped")
+			}
+			if !req.Auth.PasswordAuth.Enabled || req.Auth.PasswordAuth.Password != c.secret {
+				t.Errorf("PasswordAuth round-trip: expected enabled with %q, got enabled=%v %q",
+					c.secret, req.Auth.PasswordAuth.Enabled, req.Auth.PasswordAuth.Password)
+			}
+
+			if req.Auth.PinAuth == nil {
+				t.Fatal("PinAuth should be sent, not dropped")
+			}
+			if !req.Auth.PinAuth.Enabled || req.Auth.PinAuth.Pin != c.secret {
+				t.Errorf("PinAuth round-trip: expected enabled with %q, got enabled=%v %q",
+					c.secret, req.Auth.PinAuth.Enabled, req.Auth.PinAuth.Pin)
+			}
+
+			if req.Auth.HeaderAuths == nil || len(*req.Auth.HeaderAuths) != 2 {
+				t.Fatal("HeaderAuths should carry both entries")
+			}
+			for i, want := range []string{c.secret, "always-set"} {
+				if h := (*req.Auth.HeaderAuths)[i]; !h.Enabled || h.Value != want {
+					t.Errorf("header_auths[%d] round-trip: expected enabled with %q, got enabled=%v %q",
+						i, want, h.Enabled, h.Value)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The API never returns reverse proxy auth secrets, and the mapping stored that blank as an empty string. An imported service holds "" for password and pin while a configuration that omits them holds null, so plan reports "" -> null on every run. The only converging configuration is a literal pin = "", which misstates the secret that is actually set.

Reproduced on a self-hosted deployment with v0.0.10 from the registry. GET /api/reverse-proxies/services/{id} returns "pin": "" for a service with pin_auth enabled. Plan after a config-driven import, trimmed to the auth object:

      ~ auth               = {
            bearer_auth   = {
                enabled = false
            }
          ~ password_auth = {
                enabled  = false
              - password = (sensitive value) -> null
            }
          ~ pin_auth      = {
                enabled = true
              - pin     = (sensitive value) -> null
            }
        }

    Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.

A disabled auth block drifts too, as password_auth shows above.

Refreshes do not break because preserveAuthSecrets restores the secret from the plan on Create and Update and from prior state on Read. Import is where there is nothing to restore from, so the mapped value is what lands in state.

The blank is structural. Service.ToAPIResponse (management/internals/modules/reverseproxy/service/service.go:271, netbird
v0.77.1-0.20260818164913-ecfbd686b807) builds the auth config without the three secret fields, and they are plain strings with no omitempty. Target custom_headers is copied through in full, so it is left alone.

header_auths[].value is Required, so a configuration can never omit it and it never showed the perpetual diff. It is mapped the same way for consistency: null is the truthful representation of a value the API withholds.

Applying the dirty plan does not lose the secret for a method that is enabled on both the stored and the incoming service: preserveExistingAuthSecrets swaps the stored value back in (manager/manager.go:723). A disabled method is not covered by that guard, but this PR does not change it, since the provider sent "" there before as well.

The data source has no prior state and shares the mapping, so a consumer of netbird_reverse_proxy_service now reads null where it read "". That "" was a constant rather than data, so any comparison against it was a tautology.

netbird_agent_network_provider already returns null in this situation, with api_key documented as "Not returned by the API (sealed at rest)". setup_key.key and scim.auth_token are Computed-only, so a blank there never conflicts with a configuration
and they stay out of scope.

A state imported under an earlier version keeps its "" until the next apply, since Read restores it from prior state as described above.

Built from this branch and injected with dev_overrides, the same import plans nothing:

    Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.

Test_reverseProxyServiceRoundtrip_authSecrets maps a service both ways, once with the secrets blanked and once with them set. Against the old mapping the blanked case fails on all three fields; making the pin always null fails the case where it is set.

The existing import steps cannot catch this: reverse_proxy_acc_test.go:231, :595, :822 and :872 list these attributes in ImportStateVerifyIgnore, and ImportStateVerify does not run a plan. There is no config-driven-import idiom in the suite today, so covering it at that level would be new ground rather than a case added to an existing test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reverse proxy authentication secret handling for passwords, PINs, and header authentication.
  * Prevented redacted values returned by the API from overwriting configured secrets during updates.
  * Preserved header authentication entries and their enabled status, including when individual secret values are blanked.

* **Documentation**
  * Clarified secret preservation behavior for header authentication.

* **Tests**
  * Added coverage for redacted and non-redacted authentication secrets across supported authentication methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->